### PR TITLE
Build: browserify is only a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "browserify": "^11.0.1",
     "es6-promise": "^2.0.1",
     "jsbn": "git+https://github.com/andyperlitch/jsbn.git",
     "lodash.assign": "^3.2.0",
@@ -43,7 +42,7 @@
     "uuid": "^2.0.1"
   },
   "devDependencies": {
-    "browserify": "^8.1.3",
+    "browserify": "^11.0.1",
     "chai": "^1.10.0",
     "conventional-changelog": "^0.4.3",
     "del": "^1.1.1",


### PR DESCRIPTION
"browserify" is listed in both "dependencies" and "devDependencies", but only needed when developing/building.