### PR TITLE
Breaking: use external implementation of base64url (Close #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var jose = require('node-jose');
 
 This library uses [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) for nearly every operation.
 
-This library supports [Browserify](http://browserify.org/).  To use in a web browser, `require('node-kms')` and bundle with the rest of your app.
+This library supports [Browserify](http://browserify.org/).  To use in a web browser, `require('node-jose')` and bundle with the rest of your app.
 
 The content to be signed/encrypted or returned from being verified/decrypted are [Buffer](https://nodejs.org/api/buffer.html) objects.
 
@@ -448,6 +448,8 @@ buff = jose.util.asBuffer(input);
 
 ### URI-Safe Base64 ###
 
+This exposes [base64url](https://github.com/brianloveswords/base64url)'s `encode` and `toBuffer` methods as `encode` and `decode` (respectively).
+
 To convert from a Buffer to a base64uri-encoded String:
 
 ```
@@ -460,7 +462,7 @@ To convert a String to a base64uri-encoded String:
 // explicit encoding
 output = jose.util.base64url.encode(input, "utf8");
 
-// implied "binary" encoding
+// implied "utf8" encoding
 output = jose.util.base64url.encode(input);
 ```
 
@@ -468,12 +470,6 @@ To convert a base64uri-encoded String to a Buffer:
 
 ```
 var output = jose.util.base64url.decode(input);
-```
-
-To convert a base64uri-encoded String to a String:
-
-```
-output = jose.util.base64url.decode(input, "utf8");
 ```
 
 ### Random Bytes ###

--- a/lib/util/base64url.js
+++ b/lib/util/base64url.js
@@ -5,69 +5,35 @@
  */
 "use strict";
 
+var impl = require("base64url");
+
 /**
  * @namespace base64url
  * @description
  * Provides methods to encode and decode data according to the
  * base64url alphabet.
  */
-var base64url = exports;
-/**
- * Encodes the input to base64url.
- *
- * If {input} is a Buffer, then {encoding} is ignored. Otherwise,
- * {encoding} can be one of "binary", "base64", "hex", "utf8".
- *
- * @param {Buffer|String} input The data to encode.
- * @param {String} [encoding = binary] The input encoding format.
- * @returns {String} the base64url encoding of {input}.
- */
-base64url.encode = function(input, encoding) {
-  var fn = function(match) {
-    switch(match) {
-      case "+": return "-";
-      case "/": return "_";
-      case "=": return "";
-    }
-    // should never happen
-  };
-
-  encoding = encoding || "binary";
-  if (Buffer.isBuffer(input)) {
-    input = input.toString("base64");
-  } else {
-    if ("undefined" !== typeof ArrayBuffer && input instanceof ArrayBuffer) {
-      input = new Uint8Array(input);
-    }
-    input = new Buffer(input, encoding).toString("base64");
-  }
-
-  return input.replace(/\+|\/|\=/g, fn);
+var base64url = {
+  /**
+   * @function
+   * Encodes the input to base64url.
+   *
+   * If {input} is a Buffer, then {encoding} is ignored. Otherwise,
+   * {encoding} can be one of "binary", "base64", "hex", "utf8".
+   *
+   * @param {Buffer|String} input The data to encode.
+   * @param {String} [encoding = binary] The input encoding format.
+   * @returns {String} the base64url encoding of {input}.
+   */
+  encode: impl.encode,
+  /**
+   * @function
+   * Decodes the input from base64url.
+   *
+   * @param {String} input The data to decode.
+   * @returns {Buffer|String} the base64url decoding of {input}.
+   */
+  decode: impl.toBuffer
 };
-/**
- * Decodes the input from base64url.
- *
- * If {encoding} is not specified, then this method returns a Buffer.
- * Othewise, {encoding} can be one of "binary", "base64", "hex", "utf8";
- * this method then returns a string matching the given encoding.
- *
- * @param {String} input The data to decode.
- * @param {String} [encoding] The output encoding format.
- * @returns {Buffer|String} the base64url decoding of {input}.
- */
-base64url.decode = function(input, encoding) {
-  var fn = function(match) {
-    switch(match) {
-      case "-": return "+";
-      case "_": return "/";
-    }
-    // should never happen
-  };
 
-  input = input.replace(/\-|\_/g, fn);
-  var output = new Buffer(input, "base64");
-  if (encoding) {
-    output = output.toString(encoding);
-  }
-  return output;
-};
+module.exports = base64url;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "base64url": "^1.0.4",
     "es6-promise": "^2.0.1",
     "jsbn": "git+https://github.com/andyperlitch/jsbn.git",
     "lodash.assign": "^3.2.0",

--- a/test/util/base64url-test.js
+++ b/test/util/base64url-test.js
@@ -37,8 +37,8 @@ describe("util/base64url", function() {
     assert.equal(output, "4oC5aGVsbG8gd29ybGQh4oC6");
   });
 
-  it("should encode a (binary) string", function() {
-    var input = "\xe2\x80\xb9hello world!\xe2\x80\xba";
+  it("should encode a (utf8) string", function() {
+    var input = "‹hello world!›";
     var output = utils.base64url.encode(input);
     assert.equal(output, "4oC5aGVsbG8gd29ybGQh4oC6");
   });
@@ -84,27 +84,11 @@ describe("util/base64url", function() {
     assert.deepEqual(output, expected);
   });
 
-  it("should decode a string to a string", function() {
-    var input, output;
-
-    input = "4oC5aGVsbG8gd29ybGQh4oC6";
-    output = utils.base64url.decode(input, "binary");
-    assert.equal(output, "\xe2\x80\xb9hello world!\xe2\x80\xba");
-
-    input = "4oC5aGVsbG8gd29ybGQh4oC6";
-    output = utils.base64url.decode(input, "utf8");
-    assert.equal(output, "‹hello world!›");
-
-    input = "4oC5aGVsbG8gd29ybGQh4oC6";
-    output = utils.base64url.decode(input, "hex");
-    assert.equal(output, "e280b968656c6c6f20776f726c6421e280ba");
-  });
-
   it("should decode the rainbow!", function() {
     var input, output;
 
     input = "Pfv_Oeu-Ndt9Mcs8Lbr7Kaq6JZp5IYo4HXn3GWm2FVl1EUk0DTjzCSiyBRhxAQgw";
-    output = utils.base64url.decode(input, "hex");
+    output = utils.base64url.decode(input).toString("hex");
     assert.equal(output, "3dfbff39ebbe35db7d31cb3c2dbafb29aaba259a79218a381d79f71969b61559751149340d38f30928b2051871010830");
   });
 });


### PR DESCRIPTION
This replaces the internal implementation for base64url encoding/decoding with one from https://github.com/brianloveswords/base64url.  The breaking change here is `.decode(string)` -- previously it returned a Buffer, or a string if an explicit encoding was provided.  Now it only ever returns a buffer.