### PR TITLE
When an assumed key is provided, use it

### DIFF
--- a/lib/jwe/decrypt.js
+++ b/lib/jwe/decrypt.js
@@ -105,7 +105,7 @@ function JWEDecrypter(ks) {
 
             prekey = rcpt.encrypted_key || "";
             prekey = base64url.decode(prekey);
-            algKey = keystore.get({
+            algKey = assumedKey || keystore.get({
               use: "enc",
               alg: rcpt.header.alg,
               kid: rcpt.header.kid

--- a/lib/jws/verify.js
+++ b/lib/jws/verify.js
@@ -89,7 +89,7 @@ var JWSVerifier = function(ks) {
           var content = new Buffer((sig.protected || "") + "." + input.payload, "ascii");
 
           var algPromise,
-              algKey = keystore.get({
+              algKey = assumedKey || keystore.get({
             use: "sig",
             alg: sig.header.alg,
             kid: sig.header.kid


### PR DESCRIPTION
Previously when a key was provided to decrypt it would use the keys keystore to find a key.
If the given key was not the first key found in the keystore, then the decryption would fail.

suggested to fix #14