### PR TITLE
Fix: base64url does not work on IE (fix #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ buff = jose.util.asBuffer(input);
 
 ### URI-Safe Base64 ###
 
-This exposes [base64url](https://github.com/brianloveswords/base64url)'s `encode` and `toBuffer` methods as `encode` and `decode` (respectively).
+This exposes [urlsafe-base64](https://github.com/RGBboy/urlsafe-base64)'s `encode` and `decode` methods as `encode` and `decode` (respectively).
 
 To convert from a Buffer to a base64uri-encoded String:
 

--- a/lib/util/base64url.js
+++ b/lib/util/base64url.js
@@ -5,7 +5,7 @@
  */
 "use strict";
 
-var impl = require("base64url");
+var impl = require("urlsafe-base64");
 
 /**
  * @namespace base64url
@@ -33,7 +33,7 @@ var base64url = {
    * @param {String} input The data to decode.
    * @returns {Buffer|String} the base64url decoding of {input}.
    */
-  decode: impl.toBuffer
+  decode: impl.decode
 };
 
 module.exports = base64url;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "base64url": "^1.0.4",
     "es6-promise": "^2.0.1",
     "jsbn": "git+https://github.com/andyperlitch/jsbn.git",
     "lodash.assign": "^3.2.0",
@@ -40,6 +39,7 @@
     "lodash.uniq": "^3.2.1",
     "long": "^2.2.3",
     "node-forge": "git+https://github.com/linuxwolf/forge.git#master",
+    "urlsafe-base64": "git+https://github.com/linuxwolf/urlsafe-base64.git#encoding",
     "uuid": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Switches from brianloveswords/base64url to RGBboy/urlsafe-base64 (patched).

PR submitted for an enhancement to .encode strings (and arrays, arraybuffers, typed arrays).