### PR TITLE
Fix: address errors with setImmediate in IE

### DIFF
--- a/lib/deps/forge.js
+++ b/lib/deps/forge.js
@@ -92,4 +92,11 @@ modeRaw.prototype.decrypt = function(input, output) {
   forge.cipher.registerAlgorithm(name, factory);
 })();
 
+// Prevent nextTick from being used when possible
+if ("function" === typeof setImmediate) {
+  forge.util.setImmediate = forge.util.nextTick = function(callback) {
+    setImmediate(callback);
+  };
+}
+
 module.exports = forge;


### PR DESCRIPTION
The changes to setImmediate to address errors in node v0.10 re-introduced problems with IE10.  Latest seems to work with IE10 and node v0.10.