### PR TITLE
Adds thumbprint support for JWK

### DIFF
--- a/lib/jwk/basekey.js
+++ b/lib/jwk/basekey.js
@@ -60,9 +60,9 @@ var JWKBaseKeyObject = function(kty, ks, props, cfg) {
   // https://tools.ietf.org/html/rfc7638
   props.kid = props.kid;
   if(!props.kid){
-    var shasum = crypto.createHash('sha256');
-    var required_members = JSON.stringify({e: base64url.encode(props.e),kty: props.kty, n:base64url.encode(props.n)})
-    var digest = shasum.update(required_members).digest();
+    var shasum = crypto.createHash("sha256");
+    var requiredMembers = JSON.stringify({e: base64url.encode(props.e), kty: props.kty, n: base64url.encode(props.n)});
+    var digest = shasum.update(requiredMembers).digest();
     var thumbprint = digest.toJSON().data;
     //TODO: Expose thumbprint as a string property
     //props.thumbprint = thumbprint;

--- a/lib/jwk/basekey.js
+++ b/lib/jwk/basekey.js
@@ -12,7 +12,8 @@ var clone = require("lodash.clone"),
     omit = require("lodash.omit"),
     pick = require("lodash.pick"),
     uniq = require("lodash.uniq"),
-    uuid = require("uuid");
+    crypto = require("crypto"),
+    base64url = require("../util/base64url");
 
 var ALGORITHMS = require("../algorithms"),
     CONSTANTS = require("./constants.js"),
@@ -55,8 +56,18 @@ var JWKBaseKeyObject = function(kty, ks, props, cfg) {
   // force certain values
   props = clone(props);
   props.kty = kty;
-  props.kid = props.kid || uuid();
-
+  // kid is the base64url encoded thumbprint of the key
+  // https://tools.ietf.org/html/rfc7638
+  props.kid = props.kid;
+  if(!props.kid){
+    var shasum = crypto.createHash('sha256');
+    var required_members = JSON.stringify({e: base64url.encode(props.e),kty: props.kty, n:base64url.encode(props.n)})
+    var digest = shasum.update(required_members).digest();
+    var thumbprint = digest.toJSON().data;
+    //TODO: Expose thumbprint as a string property
+    //props.thumbprint = thumbprint;
+    props.kid = base64url.encode(thumbprint);
+  }
   // setup base info
   var included = Object.keys(HELPERS.COMMON_PROPS).map(function(p) {
     return HELPERS.COMMON_PROPS[p].name;


### PR DESCRIPTION
The thumbprint is calculated as described in https://tools.ietf.org/html/rfc7638
This is a breaking changes as it alters the definition of the kid.