### PR TITLE
fix wrong decryption sample code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ To decrypt a JWE, and retrieve the plaintext:
 
 ```
 jose.JWE.createDecrypt(keystore).
-        verify(input).
+        decrypt(input).
         then(function(result) {
           // {result} is a Object with:
           // *  header: the combined 'protected' and 'unprotected' header members
@@ -469,7 +469,7 @@ To decrypt a JWE using an implied key:
 
 ```
 jose.JWE.createDecrypt(key).
-        verify(input).
+        decrypt(input).
         then(function(result) {
           // ....
         });


### PR DESCRIPTION
README.md claims that one has to call `verify` to decrypt. The correct call is `decrypt`.