### PR TITLE
fix: polyfill always loaded with node-jose

### DIFF
--- a/lib/algorithms/helpers.js
+++ b/lib/algorithms/helpers.js
@@ -6,7 +6,9 @@
  */
 "use strict";
 
-require("es6-promise").polyfill();
+if (typeof Promise === "undefined") {
+  require("es6-promise").polyfill();
+}
 
 // ###
 exports.int32ToBuffer = function(v, b) {


### PR DESCRIPTION
There's one remaining occurence of `require("es6-promise").polyfill();` which is not wrapped in check statement. Now while the choice of polyfill is questionable (i.e. why not just include Bluebird) the absolute minimum requirement is that the default ES6 Promise is not replaced after requiring node-jose.

```
$ node -v
v4.2.2
$ node
> Promise
[Function: Promise]
> require('node-jose')
...
> Promise
{ [Function: lib$es6$promise$promise$$Promise]
  all: [Function: lib$es6$promise$promise$all$$all],
  race: [Function: lib$es6$promise$promise$race$$race],
  resolve: [Function: lib$es6$promise$promise$resolve$$resolve],
  reject: [Function: lib$es6$promise$promise$reject$$reject],
  _setScheduler: [Function: lib$es6$promise$asap$$setScheduler],
  _setAsap: [Function: lib$es6$promise$asap$$setAsap],
  _asap: [Function: asap] }
> Promise.defer
undefined

^^^
what a polyfill...
```