### PR TITLE
Build: Separate RSA PEM tests into their own testcase.

### DIFF
--- a/test/jwk/keystore-test.js
+++ b/test/jwk/keystore-test.js
@@ -706,6 +706,11 @@ describe("jwk/keystore", function() {
           var promise = JWK.store.KeyStore.asKey(pem.rawPrivate, "pem");
           promise = promise.then(function(jwk) {
             assert.ok(JWK.store.KeyStore.asKey(jwk));
+            return jwk.toPEM(true);
+          });
+          promise = promise.then(function(pem) {
+            assert.match(pem, /^-----BEGIN RSA PRIVATE KEY-----\r\n/);
+            assert.match(pem, /\r\n-----END RSA PRIVATE KEY-----\r\n$/);
           });
 
           return promise;
@@ -722,6 +727,11 @@ describe("jwk/keystore", function() {
           var promise = JWK.store.KeyStore.asKey(pem.spki, "pem");
           promise = promise.then(function(jwk) {
             assert.ok(JWK.store.KeyStore.asKey(jwk));
+            return jwk.toPEM(false);
+          });
+          promise = promise.then(function(pem) {
+            assert.match(pem, /^-----BEGIN PUBLIC KEY-----\r\n/);
+            assert.match(pem, /\r\n-----END PUBLIC KEY-----\r\n$/);
           });
 
           return promise;

--- a/test/jwk/rsakey-test.js
+++ b/test/jwk/rsakey-test.js
@@ -241,6 +241,18 @@ describe("jwk/RSA", function() {
       algs = JWK.RSA.config.algorithms(keys, "verify");
       assert.deepEqual(algs, []);
     });
+    it("exports PEM for public key", function() {
+      var pem = JWK.RSA.config.convertToPEM(keyPair.public, false);
+      assert.isString(pem);
+      assert.match(pem, /^-----BEGIN PUBLIC KEY-----\r\n/);
+      assert.match(pem, /\r\n-----END PUBLIC KEY-----\r\n$/);
+    });
+    it("exports PEM for private key", function() {
+      var pem = JWK.RSA.config.convertToPEM(keyPair.private, true);
+      assert.isString(pem);
+      assert.match(pem, /^-----BEGIN RSA PRIVATE KEY-----\r\n/);
+      assert.match(pem, /\r\n-----END RSA PRIVATE KEY-----\r\n$/);
+    });
   });
   describe("keystore integration", function() {
     it("generates a 'RSA' JWK", function() {
@@ -347,17 +359,6 @@ describe("jwk/RSA", function() {
           kid: "someid"
         });
         assert.deepEqual(key.toJSON(true), json);
-        var privPEM = key.toPEM(true);
-        assert.isString(privPEM);
-        assert.match(privPEM, /^-----BEGIN RSA PRIVATE KEY-----\r\n/);
-        assert.match(privPEM, /\r\n-----END RSA PRIVATE KEY-----\r\n$/);
-
-        var pubPEM = key.toPEM();
-        assert.isString(pubPEM);
-        assert.match(pubPEM, /^-----BEGIN PUBLIC KEY-----\r\n/);
-        assert.match(pubPEM, /\r\n-----END PUBLIC KEY-----\r\n$/);
-
-        assert.equal(pubPEM, key.toPEM(false));
       });
 
       return promise;


### PR DESCRIPTION
Original PEM tests were included as part of another testcase.  This separates it out to be more explicit in the reporting.