### PR TITLE
Fix: only honor isPrivate if it is actually a Boolean

### DIFF
--- a/lib/jwk/basekey.js
+++ b/lib/jwk/basekey.js
@@ -357,7 +357,7 @@ var JWKBaseKeyObject = function(kty, ks, props, cfg) {
       result = merge(result,
                        json.base,
                        json.public,
-                       (isPrivate) ? json.private : {},
+                       ("boolean" === typeof isPrivate && isPrivate) ? json.private : {},
                        json.extra);
       result = omit(result, excluded || []);
 
@@ -417,7 +417,7 @@ var JWKBaseKeyObject = function(kty, ks, props, cfg) {
       result = merge(result,
                        json.base,
                        keys.public,
-                       (isPrivate) ? keys.private : {},
+                       ("boolean" === typeof isPrivate && isPrivate) ? keys.private : {},
                        json.extra);
       result = omit(result, (excluded || []).concat("length"));
 

--- a/test/jwk/basekey-test.js
+++ b/test/jwk/basekey-test.js
@@ -629,6 +629,31 @@ describe("jwk/basekey", function() {
         "alg": "A128GCM"
       });
     });
+    it("ignores isPrivate if not a Boolean", function() {
+      var props = {
+        kid: "somevalue",
+        pub: "Lc3EY3_96tfej0F7Afa0TQ",
+        prv: "SBh6LBt1DBTeyHTvwDgSjg",
+        use: "enc",
+        alg: "A128GCM"
+      };
+      var inst = createInstance(props);
+
+      assert.deepEqual(inst.toObject("42"), {
+        "kty": "DUMMY",
+        "kid": "somevalue",
+        "pub": util.base64url.decode("Lc3EY3_96tfej0F7Afa0TQ"),
+        "use": "enc",
+        "alg": "A128GCM"
+      });
+      assert.deepEqual(inst.toJSON("42"), {
+        "kty": "DUMMY",
+        "kid": "somevalue",
+        "pub": "Lc3EY3_96tfej0F7Afa0TQ",
+        "use": "enc",
+        "alg": "A128GCM"
+      });
+    });
   });
 
   describe("thumbprints", function() {


### PR DESCRIPTION
Prevents the private key being included if a JWK is nested inside another object and toJSON() is implicitly called.