### PR TITLE
Eliminates warning when using with webpack

### DIFF
--- a/lib/algorithms/helpers.js
+++ b/lib/algorithms/helpers.js
@@ -49,8 +49,7 @@ function getCryptoSubtle() {
 function getCryptoNodeJS() {
   var crypto;
   try {
-    var pkgname = "crypto";
-    crypto = require(pkgname);
+    crypto = require("crypto");
   } catch (err) {
     return undefined;
   }


### PR DESCRIPTION
Can't see why this is needed. Also it makes webpack generate a warning on build
```
./~/node-jose/lib/algorithms/helpers.js
Critical dependencies:
53:13-29 the request of a dependency is an expression
 @ ./~/node-jose/lib/algorithms/helpers.js 53:13-29
```