### PR TITLE
use callback signature for forge.pki.rsa.generateKeyPair in node environments

### DIFF
--- a/lib/jwk/rsakey.js
+++ b/lib/jwk/rsakey.js
@@ -6,7 +6,8 @@
 "use strict";
 
 var forge = require("../deps/forge.js"),
-    rsau = require("../algorithms/rsa-util");
+    rsau = require("../algorithms/rsa-util"),
+    nodeCrypto = require("../algorithms/helpers").nodeCrypto;
 
 var JWK = {
   BaseKey: require("./basekey.js"),
@@ -257,40 +258,57 @@ var JWKRsaFactory = {
   },
   generate: function(size) {
     // TODO: validate key sizes
-    var key = forge.pki.rsa.generateKeyPair({
-      bits: size,
-      e: 0x010001
+    var promise;
+
+    if (nodeCrypto) {
+      promise = new Promise(function (resolve, reject) {
+        forge.pki.rsa.generateKeyPair({
+          bits: size,
+          e: 0x010001
+        }, function (err, key) {
+          if (err) return reject(err);
+          resolve(key.privateKey);
+        });
+      });
+    } else {
+      var key = forge.pki.rsa.generateKeyPair({
+        bits: size,
+        e: 0x010001
+      });
+      promise = Promise.resolve(key.privateKey);
+    };
+
+    return promise.then(function (key) {
+
+      // convert to JSON-ish
+      var result = {};
+      [
+        "e",
+        "n",
+        "d",
+        "p",
+        "q",
+        {incoming: "dP", outgoing: "dp"},
+        {incoming: "dQ", outgoing: "dq"},
+        {incoming: "qInv", outgoing: "qi"}
+      ].forEach(function(f) {
+        var incoming,
+            outgoing;
+
+        if ("string" === typeof f) {
+          incoming = outgoing = f;
+        } else {
+          incoming = f.incoming;
+          outgoing = f.outgoing;
+        }
+
+        if (incoming in key) {
+          result[outgoing] = convertBNtoBuffer(key[incoming]);
+        }
+      });
+
+      return result;
     });
-    key = key.privateKey;
-
-    // convert to JSON-ish
-    var result = {};
-    [
-      "e",
-      "n",
-      "d",
-      "p",
-      "q",
-      {incoming: "dP", outgoing: "dp"},
-      {incoming: "dQ", outgoing: "dq"},
-      {incoming: "qInv", outgoing: "qi"}
-    ].forEach(function(f) {
-      var incoming,
-          outgoing;
-
-      if ("string" === typeof f) {
-        incoming = outgoing = f;
-      } else {
-        incoming = f.incoming;
-        outgoing = f.outgoing;
-      }
-
-      if (incoming in key) {
-        result[outgoing] = convertBNtoBuffer(key[incoming]);
-      }
-    });
-
-    return Promise.resolve(result);
   },
   import: function(input) {
     if (validators.oid !== input.keyOid) {


### PR DESCRIPTION
Generating RSA keys blocks the event loop, this is painfully obvious with 2048 bit size. Using this simple script you can check the before and after for this PR.

```js
'use strict';

var jose = require('.');
var ks = jose.JWK.createKeyStore();

let i = 0;

let count = () => {
  console.log(i++);
  setImmediate(count);
}

count();

console.log('RSA pre');
ks.generate('RSA', 2048).then(() => console.log('RSA callback')).then(() => process.exit(0))
console.log('RSA after');
```

*before*
```
0
RSA pre
(blocks loop)
RSA after
RSA callback
exits
```

*after*
```
0
RSA pre
RSA after
1
2
3
... (continues executing)
RSA callback
exits
```