### PR TITLE
Build: include browser tests in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,31 @@
 language: node_js
-node_js:
-  - '0.10'
-  - '0.12'
-  - 'iojs'
-  - '4'
-  - '5'
-  - '6'
-
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+    - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
+    - g++-4.8
+node_js:
+- '0.10'
+- '0.12'
+- iojs
+- '4'
+- '5'
+- '6'
 env:
   matrix:
+  - CXX=g++-4.8 TASKS=test:nodejs
+matrix:
+  include:
+  - node_js: 6
     env:
-      - TASKS=test:nodejs 
-      - EXTRAS=""
-  global:
-    - CXX=g++-4.8
-
+    - CXX=g++-4.8 TASKS=travis:browser
+    addons:
+      firefox: latest
+      sauce_connect: true
+before_script:
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
+- sleep 5 # give xvfb some time to start
 script:
-  - ./node_modules/.bin/gulp $TASKS $EXTRAS
+- ./node_modules/.bin/gulp $TASKS

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-mocha": "^2.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^1.1.0",
+    "gulp-util": "^3.0.7",
     "istanbul": "^0.4.0",
     "jose-cookbook": "git+https://github.com/ietf-jose/cookbook.git",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
This includes SauceLabs for pushes, and xvfb+Firefox for PRs.