### PR TITLE
remove urlsafe enc/dec tar dependency

### DIFF
--- a/lib/util/base64url.js
+++ b/lib/util/base64url.js
@@ -5,7 +5,7 @@
  */
 "use strict";
 
-var impl = require("urlsafe-base64");
+var impl = require("base64url");
 
 /**
  * @namespace base64url
@@ -25,7 +25,17 @@ var base64url = {
    * @param {String} [encoding = binary] The input encoding format.
    * @returns {String} the base64url encoding of {input}.
    */
-  encode: impl.encode,
+  encode: function encode(buffer, encoding) {
+    if (buffer instanceof ArrayBuffer) {
+      buffer = new Uint8Array(buffer);
+    }
+
+    if (!Buffer.isBuffer(buffer)) {
+      buffer = new Buffer(buffer, encoding);
+    }
+
+    return impl.encode(buffer);
+  },
   /**
    * @function
    * Decodes the input from base64url.
@@ -33,7 +43,7 @@ var base64url = {
    * @param {String} input The data to decode.
    * @returns {Buffer|String} the base64url decoding of {input}.
    */
-  decode: impl.decode
+  decode: impl.toBuffer
 };
 
 module.exports = base64url;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "base64url": "^2.0.0",
     "es6-promise": "^4.0.5",
     "jsbn": "^1.1.0",
     "lodash.assign": "^4.0.8",
@@ -40,7 +41,6 @@
     "lodash.uniq": "^4.2.1",
     "long": "^3.1.0",
     "node-forge": "https://github.com/linuxwolf/forge/archive/browserify.tar.gz",
-    "urlsafe-base64": "https://github.com/linuxwolf/urlsafe-base64/archive/encoding.tar.gz",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR implements the two extra features of linuxwolf/urlsafe-base64 on top of a standard published package.

In combination with #103 this will resolve #96 