### PR TITLE
Update: prevent embedding 'oct' keys in JWS objects

### DIFF
--- a/lib/jwe/encrypt.js
+++ b/lib/jwe/encrypt.js
@@ -601,6 +601,9 @@ function createEncrypt(opts, rcpts) {
       if (ref) {
         jwk = key.toJSON();
         if ("jwk" === ref) {
+          if ("oct" === key.kty) {
+            return Promise.reject(new Error("cannot embed key"));
+          }
           header.jwk = jwk;
         } else if (ref in jwk) {
           header[ref] = jwk[ref];

--- a/lib/jws/sign.js
+++ b/lib/jws/sign.js
@@ -324,6 +324,9 @@ function createSign(opts, signs) {
       if (ref) {
         jwk = key.toJSON();
         if ("jwk" === ref) {
+          if ("oct" === key.kty) {
+            return Promise.reject(new Error("cannot embed key"));
+          }
           header.jwk = jwk;
         } else if (ref in jwk) {
           header[ref] = jwk[ref];

--- a/test/jwe/embed-test.js
+++ b/test/jwe/embed-test.js
@@ -1,0 +1,58 @@
+/*!
+ *
+ * Copyright (c) 2016 Cisco Systems, Inc. See LICENSE file.
+ */
+"use strict";
+
+var chai = require("chai");
+
+var JWK = require("../../lib/jwk");
+var JWE = require("../../lib/jwe");
+
+var assert = chai.assert;
+
+describe.only("jwe/embedded", function() {
+  var keys  = {
+    "oct": {
+      "kty": "oct",
+      "kid": "BBbx9f-quvmBp5gHzO1LA1r3Fm7MsXwQovuLoIq4Des",
+      "k": "rmY1vk9qj34HAYWSc2aQJg"
+    }
+    // TODO: RSA and EC key tests
+  }
+  var payload = new Buffer("There and back again – A Hobbit's Tale, by Bilbo Baggins", "utf8");
+
+  before(function() {
+    var all = Object.keys(keys);
+    all = all.map(function(t) {
+      return JWK.asKey(keys[t]).
+             then(function(jwk) {
+               keys[t] = jwk;
+             });
+    });
+    return Promise.all(all);
+  });
+
+  describe("oct", function() {
+    it("failed to embed a symmetric key", function() {
+      var badKey = keys.oct;
+      var opts = {
+        format: "general",
+        protect: false
+      };
+      var jwe = JWE.createEncrypt(opts, {
+        key: badKey,
+        reference: "jwk"
+      });
+      jwe.update("You shall not pass!", "utf8");
+      var p = jwe.final();
+      p = p.then(function() {
+        assert.ok(false, "unexpected success");
+      }, function(err) {
+        assert.instanceOf(err, Error);
+        assert.equal(err.message, "cannot embed key");
+      });
+      return p;
+    });
+  });
+});

--- a/test/jws/embed-test.js
+++ b/test/jws/embed-test.js
@@ -114,4 +114,39 @@ describe("jws/embedded", function() {
       return p;
     });
   });
+
+  describe("invalid", function() {
+    var badKey = {
+      "kty": "oct",
+      "kid": "dNr5z3PMFZKDp7Kh7uAxmpuSiOrm0E3WZDEscsoRXeE",
+      "alg": "HS256",
+      "k": "UHZVSbwjVqqFCcdQUvrnX7gLXBIfMEkecVeYE7tD7fo"
+    };
+    before(function() {
+      return JWK.asKey(badKey).
+             then(function(result) {
+               badKey = result;
+             });
+    });
+    it("failed to embed a symmetric key", function() {
+      var opts = {
+        format: "general",
+        protect: false
+      };
+      var jws = JWS.createSign(opts, {
+        key: badKey,
+        reference: "jwk"
+      });
+      jws.update("You shall not pass!", "utf8");
+
+      var p = jws.final();
+      p = p.then(function() {
+        assert.ok(false, "unexpected fail");
+      }, function(err) {
+        assert.instanceOf(err, Error);
+        assert.equal(err.message, "cannot embed key");
+      });
+      return p;
+    });
+  });
 });


### PR DESCRIPTION
Addresses #105 