### PR TITLE
prevent JWK.KeyStore#add from modifying jwk input

### DIFF
--- a/lib/jwk/keystore.js
+++ b/lib/jwk/keystore.js
@@ -314,6 +314,8 @@ var JWKStore = function(registry, parent) {
       } else if (JWKStore.isKey(jwk)) {
         // assume a complete duplicate is desired
         jwk = jwk.toJSON(true);
+      } else {
+        jwk = clone(jwk);
       }
 
       var keytype = registry.get(jwk.kty);


### PR DESCRIPTION
When adding a key to a KeyStore that is already in JSON format the input jwk is modified when creating the Key.

```javascript
var jose = require('node-jose')

// !!!! this jwk variable should not change
var jwk = {
  kty: 'RSA',
  kid: 'v9nlkBvs0_bA9zJcyfUeyqDMXT_VpSVvUvktvOmoqCI',
  e: 'AQAB',
  n: 'tyaZ2IG7DkzfhhSLDFcoGdH-JXctfTZ-C1ICc_o9BABZqY1ZDk1dhztElvKvb_FrcJDh_8uvY9E7TO7dqN6m7bUaBwICjsEXUNrGpYHkzTyPR8UpFLtzVFKmVs17nLSK4J1grgLmarBs_VAroLDc8M2djmxqkA6UuifZ3DoiWuyNho_Xw31o-qk2HY4jRSvmlvMFlLMM9zjYeznn0mFGNqghBkuk6e4ie0sQwMKZMKsvqeew19VCDOPSzsHH-W_mK67rOASk8jm6_CeYLR66yja2qMjuGh6s9h_MuhKEW8nqmmZajafKsRo2mI5l1jVRtLTdqJjBJkI3Iwys122cgw' 
}

jose.JWK.asKey(jwk).then(function () {
  console.log(jwk)
})
```
prints
```
{ 
  kty: 'RSA',
  kid: 'v9nlkBvs0_bA9zJcyfUeyqDMXT_VpSVvUvktvOmoqCI',
  e: 'AQAB',
  n: 'tyaZ2IG7DkzfhhSLDFcoGdH-JXctfTZ-C1ICc_o9BABZqY1ZDk1dhztElvKvb_FrcJDh_8uvY9E7TO7dqN6m7bUaBwICjsEXUNrGpYHkzTyPR8UpFLtzVFKmVs17nLSK4J1grgLmarBs_VAroLDc8M2djmxqkA6UuifZ3DoiWuyNho_Xw31o-qk2HY4jRSvmlvMFlLMM9zjYeznn0mFGNqghBkuk6e4ie0sQwMKZMKsvqeew19VCDOPSzsHH-W_mK67rOASk8jm6_CeYLR66yja2qMjuGh6s9h_MuhKEW8nqmmZajafKsRo2mI5l1jVRtLTdqJjBJkI3Iwys122cgw',
  'internal\u0000thumbprint': { 'SHA-256': <Buffer bf d9 e5 90 1b ec d3 f6 c0 f7 32 5c c9 f5 1e ca a0 cc 5d 3f d5 a5 25 6f 52 f9 2d bc e9 a8 a8 22> } 
}
```
now the initial input has the `'internal\u0000thumbprint'` field.


This also causes some weird behavior in verify functions
```javascript
jose.JWS.createVerify()
  .verify(input)
  .then(function (result) {
    console.log(result.header.jwk) // has 'internal\u0000thumbprint' field
  } )
```
The header returned by the verify function is not the exact header that was "signed" which may lead people to believe the `'internal\u0000thumbprint'` field was part of the signed response. 

This happens because it runs the `header.jwk` through JKW.asKey() to generate the key for the signature in `result.key`
