### PR TITLE
package: Fix wrong repository URL syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com/cisco/node-jose.git"
+    "url": "https://github.com/cisco/node-jose.git"
   },
   "keywords": [
     "crypto",


### PR DESCRIPTION
If using the scp-like Git URL syntax [1], a colon (':') must be used
after the server part. Better not use that syntax anyway but the
more common HTTP protocol, which also is GitHub's default.

[1] https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#_the_ssh_protocol