### PR TITLE
Create a Key without first creating a KeyStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,17 @@ keystore.remove(key);
 
 ### Importing and Exporting a Single Key ###
 
+To create a single "stand alone" key:
+
+```javascript
+jose.JWK.createKey("oct", 256, { alg: "A256GCM" }).
+         then(function(result) {
+           // {result} is a jose.JWK.Key
+           // {result.keystore} is a unique jose.JWK.KeyStore
+         });
+```
+
+
 To import a single Key:
 
 ```javascript

--- a/lib/jwk/keystore.js
+++ b/lib/jwk/keystore.js
@@ -657,6 +657,23 @@ JWKStore.isKey = function(obj) {
 };
 
 /**
+ * Creates a new key with the given properties.  This method is a convenience
+ * to calling `JWK.createKeyStore()` then `generate()` on the returned keystore.
+ *
+ * @param {String} kty The type of generated key
+ * @param {String|Number} [size] The size of the generated key
+ * @param {Object} [props] Additional properties to apply to the generated
+ *        key.
+ * @returns {Promise} The promise for the generated Key
+ * @throws {Error} If {kty} is not supported
+ * @see JWKStore#generate
+ */
+JWKStore.createKey = function(kty, size, props) {
+  var ks = JWKStore.createKeyStore();
+  return ks.generate(kty, size, props);
+}
+
+/**
  * Coerces the given object into a Key. If {key} is an instance of JWK.Key,
  * it is returned directly. Otherwise, this method first creates a new
  * JWK.KeyStore and calls {@link JWK.KeyStore#add} on this new KeyStore.

--- a/test/jwk/keystore-test.js
+++ b/test/jwk/keystore-test.js
@@ -495,6 +495,18 @@ describe("jwk/keystore", function() {
         assert.equal(JWK.store.KeyStore.isKey(), false);
       });
     });
+    describe("KeyStore.createKey", function() {
+      it("creates a new Key", function() {
+        var p;
+        p = JWK.store.KeyStore.createKey("oct", 256);
+        p = p.then(function (result) {
+          assert.ok(JWK.store.KeyStore.isKey(result));
+          assert.strictEqual(result.kty, "oct");
+          assert.strictEqual(result.length, 256);
+        });
+        return p;
+      });
+    });
     describe("KeyStore.asKey", function() {
       var props = {
         kty: "oct",


### PR DESCRIPTION
Provides a convenience "top-level" method to generate a key without an explicit keystore.