### PR TITLE
3.0.0 base64url

### DIFF
--- a/lib/util/base64url.js
+++ b/lib/util/base64url.js
@@ -5,12 +5,7 @@
  */
 "use strict";
 
-var impl = require("b64u");
-
-// webpack specific
-if (impl.default) {
-  impl = impl.default;
-}
+var impl = require("base64url");
 
 /**
  * @namespace base64url

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "b64u": "^2.0.0",
+    "base64url": "^3.0.0",
     "es6-promise": "^4.0.5",
     "lodash.assign": "^4.0.8",
     "lodash.clone": "^4.3.2",


### PR DESCRIPTION
I can see you're getting ready for 🤞1.0.0 or simply another minor. This is to pull the original / more "visible" base64 url package back in. See also https://github.com/cisco/node-jose/pull/179#issuecomment-389331647