### PR TITLE
Update: generate and apply header values when key wrapping

### DIFF
--- a/lib/algorithms/aes-gcm.js
+++ b/lib/algorithms/aes-gcm.js
@@ -106,7 +106,7 @@ function gcmEncryptFN(size, wrap) {
   // ### WebCryptoAPI implementation
   // TODO: cache CryptoKey sooner
   var webcrypto = function(key, pdata, props) {
-    var iv = props.iv || Buffer.alloc(0),
+    var iv = props.iv,
         adata = props.aad || props.adata || Buffer.alloc(0);
 
     try {
@@ -152,7 +152,7 @@ function gcmEncryptFN(size, wrap) {
 
   // ### NodeJS implementation
   var nodejs = function(key, pdata, props) {
-    var iv = props.iv || Buffer.alloc(0),
+    var iv = props.iv,
         adata = props.aad || props.adata || Buffer.alloc(0);
 
     try {

--- a/lib/algorithms/aes-gcm.js
+++ b/lib/algorithms/aes-gcm.js
@@ -6,17 +6,38 @@
 "use strict";
 
 var helpers = require("./helpers.js"),
+    util = require("../util"),
     CONSTANTS = require("./constants.js"),
     GCM = require("../deps/ciphermodes/gcm");
 
-function gcmEncryptFN(size) {
+function gcmEncryptFN(size, wrap) {
   function commonChecks(key, iv) {
     if (size !== (key.length << 3)) {
        throw new Error("invalid key size");
     }
-    if (12 !== iv.length) {
+    if (!iv && !wrap) {
       throw new Error("invalid iv");
     }
+    if (iv && 12 !== iv.length) {
+      throw new Error("invalid iv");
+    }
+  }
+
+  function prepareResults(results) {
+    if (wrap) {
+      var iv = util.base64url.encode(results.iv);
+      var tag = util.base64url.encode(results.tag);
+
+      results = {
+        data: results.data,
+        header: {
+          iv: iv,
+          tag: tag
+        }
+      };
+    }
+
+    return results;
   }
 
   // ### 'fallback' implementation -- uses forge
@@ -32,6 +53,8 @@ function gcmEncryptFN(size) {
     } catch (err) {
       return Promise.reject(err);
     }
+
+    iv = iv || util.randomBytes(12);
 
     // setup cipher
     cipher = GCM.createCipher({
@@ -69,10 +92,11 @@ function gcmEncryptFN(size) {
 
         // resolve with output
         var tag = cipher.tag;
-        resolve({
+        resolve(prepareResults({
           data: cdata,
+          iv: iv,
           tag: tag
-        });
+        }));
       })();
     });
 
@@ -90,6 +114,8 @@ function gcmEncryptFN(size) {
     } catch (err) {
       return Promise.reject(err);
     }
+
+    iv = iv || util.randomBytes(12);
 
     var alg = {
       name: "AES-GCM"
@@ -114,10 +140,11 @@ function gcmEncryptFN(size) {
       var cdata = result.slice(0, tagStart);
       cdata = Buffer.from(cdata);
 
-      return {
+      return prepareResults({
         data: cdata,
+        iv: iv,
         tag: tag
-      };
+      });
     });
 
     return promise;
@@ -133,6 +160,8 @@ function gcmEncryptFN(size) {
     } catch (err) {
       return Promise.reject(err);
     }
+
+    iv = iv || util.randomBytes(12);
 
     var alg = "aes-" + (key.length * 8) + "-gcm";
     var cipher;
@@ -154,14 +183,16 @@ function gcmEncryptFN(size) {
     ]);
     var tag = cipher.getAuthTag();
 
-    return {
+    return prepareResults({
       data: cdata,
+      iv: iv,
       tag: tag
-    };
+    });
   };
 
   return helpers.setupFallback(nodejs, webcrypto, fallback);
 }
+
 function gcmDecryptFN(size) {
   function commonChecks(key, iv, tag) {
     if (size !== (key.length << 3)) {
@@ -331,10 +362,12 @@ var aesGcm = {};
   "A192GCMKW",
   "A256GCMKW"
 ].forEach(function(alg) {
-  var size = parseInt(/A(\d+)GCM(?:KW)?/g.exec(alg)[1]);
+  var parts = /A(\d+)GCM(KW)?/g.exec(alg);
+  var size = parseInt(parts[1]);
+  var wrap = (parts[2] === "KW");
   aesGcm[alg] = {
-    encrypt: gcmEncryptFN(size),
-    decrypt: gcmDecryptFN(size)
+    encrypt: gcmEncryptFN(size, wrap),
+    decrypt: gcmDecryptFN(size, wrap)
   };
 });
 

--- a/lib/algorithms/aes-gcm.js
+++ b/lib/algorithms/aes-gcm.js
@@ -42,7 +42,7 @@ function gcmEncryptFN(size, wrap) {
 
   // ### 'fallback' implementation -- uses forge
   var fallback = function(key, pdata, props) {
-    var iv = props.iv || Buffer.alloc(0),
+    var iv = props.iv,
         adata = props.aad || props.adata || Buffer.alloc(0),
         cipher,
         cdata;

--- a/lib/algorithms/pbes2.js
+++ b/lib/algorithms/pbes2.js
@@ -14,6 +14,7 @@ var forge = require("../deps/forge.js"),
 
 var NULL_BUFFER = Buffer.from([0]);
 var DEFAULT_ITERATIONS = 8192;
+var DEFAULT_SALT_LENGTH = 16;
 
 function fixSalt(hmac, kw, salt) {
   var alg = "PBES2-" + hmac + "+" + kw;
@@ -152,7 +153,9 @@ function pbes2EncryptFN(hmac, kw) {
     if (0 >= itrs) {
       throw new Error("invalid iteration count");
     }
-    if (8 > salt.length) {
+    if (0 === salt.length) {
+      salt = util.randomBytes(DEFAULT_SALT_LENGTH);
+    } else if (8 > salt.length) {
       throw new Error("salt too small");
     }
     var header = {

--- a/lib/algorithms/pbes2.js
+++ b/lib/algorithms/pbes2.js
@@ -6,12 +6,14 @@
 "use strict";
 
 var forge = require("../deps/forge.js"),
+    merge = require("../util/merge.js"),
     util = require("../util"),
     helpers = require("./helpers.js"),
     CONSTANTS = require("./constants.js"),
     KW = require("./aes-kw.js");
 
 var NULL_BUFFER = Buffer.from([0]);
+var DEFAULT_ITERATIONS = 8192;
 
 function fixSalt(hmac, kw, salt) {
   var alg = "PBES2-" + hmac + "+" + kw;
@@ -30,20 +32,21 @@ function pbkdf2Fn(hash) {
     var salt = util.asBuffer(props.salt || Buffer.alloc(0), "base64u4l"),
         itrs = props.iterations || 0;
 
-    if (0 >= keyLen) {
-      throw new Error("invalid key length");
-    }
-    if (0 >= itrs) {
-      throw new Error("invalid iteration count");
-    }
-
-    props.length = keyLen;
-    props.salt = salt;
-    props.iterations = itrs;
-
-    return props;
+  if (0 >= keyLen) {
+    throw new Error("invalid key length");
+  }
+  if (0 >= itrs) {
+    throw new Error("invalid iteration count");
   }
 
+  props.length = keyLen;
+  props.salt = salt;
+  props.iterations = itrs;
+
+  return props;
+}
+
+function pbkdf2Fn(hash) {
   var fallback = function(key, props) {
     try {
       props = prepareProps(props);
@@ -138,13 +141,14 @@ function pbkdf2Fn(hash) {
 }
 
 function pbes2EncryptFN(hmac, kw) {
+  var deriveAlg = "PBKDF2-" + hmac.replace("HS", "SHA-");
   var keyLen = CONSTANTS.KEYLENGTH[kw] / 8;
 
-  var fallback = function(key, pdata, props) {
+  return function(key, pdata, props) {
     props = props || {};
 
     var salt = util.asBuffer(props.p2s || Buffer.alloc(0), "base64url"),
-        itrs = props.p2c || 0;
+      itrs = props.p2c || 0;
 
     if (0 >= itrs) {
       throw new Error("invalid iteration count");
@@ -152,145 +156,41 @@ function pbes2EncryptFN(hmac, kw) {
     if (8 > salt.length) {
       throw new Error("salt too small");
     }
+    var header = {
+      p2s: util.base64url.encode(salt),
+      p2c: itrs
+    };
     salt = fixSalt(hmac, kw, salt);
-
-    var promise;
-
-    // STEP 1: derive shared key
-    promise = new Promise(function(resolve, reject) {
-      var md = forge.md[hmac.replace("HS", "SHA").toLowerCase()].create();
-      var cb = function(err, dk) {
-        if (err) {
-          reject(err);
-        } else {
-          dk = Buffer.from(dk, "binary");
-          resolve(dk);
-        }
-      };
-
-      forge.pkcs5.pbkdf2(key.toString("binary"),
-                         salt.toString("binary"),
-                         itrs,
-                         keyLen,
-                         md,
-                         cb);
+    props = merge(props, {
+      salt: salt,
+      iterations: itrs,
+      length: keyLen
     });
 
+    var promise = Promise.resolve(key);
+    // STEP 1: derive shared key
+    promise = promise.then(function (key) {
+      return pbes2[deriveAlg].derive(key, props);
+    });
     // STEP 2: encrypt cek
-    promise = promise.then(function(dk) {
+    promise = promise.then(function (dk) {
       return KW[kw].encrypt(dk, pdata);
     });
-    return promise;
-  };
-
-  var webcrypto = function(key, pdata, props) {
-    props = props || {};
-
-    var salt = util.asBuffer(props.p2s || Buffer.alloc(0), "base64url"),
-        itrs = props.p2c || 0;
-
-    if (0 >= itrs) {
-      throw new Error("invalid iteration count");
-    }
-    if (8 > salt.length) {
-      throw new Error("salt too small");
-    }
-    salt = fixSalt(hmac, kw, salt);
-
-    var promise;
-
-    // STEP 1: derive shared key
-    var hash = hmac.replace("HS", "SHA-");
-    promise = Promise.resolve(key);
-    promise = promise.then(function(keyval) {
-      return helpers.subtleCrypto.importKey("raw", keyval, "PBKDF2", false, ["deriveKey"]);
-    });
-    promise = promise.then(function(key) {
-      var mainAlgo = {
-        name: "PBKDF2",
-        salt: salt,
-        iterations: itrs,
-        hash: hash
-      };
-      var deriveAlgo = {
-        name: "AES-KW",
-        length: keyLen * 8
-      };
-
-      return helpers.subtleCrypto.deriveKey(mainAlgo, key, deriveAlgo, true, ["wrapKey", "unwrapKey"]);
-    });
-    // STEP 2: encrypt cek
-    promise = promise.then(function(dk) {
-      // assume subtleCrypto for keywrap
-      return Promise.all([
-        helpers.subtleCrypto.importKey("raw", pdata, { name: "HMAC", hash: "SHA-256" }, true, ["sign"]),
-        dk
-      ]);
-    });
-    promise = promise.then(function(keys) {
-      return helpers.subtleCrypto.wrapKey("raw",
-                                          keys[0], // key
-                                          keys[1], // wrappingKey
-                                          "AES-KW");
-    });
-    promise = promise.then(function(result) {
-      result = Buffer.from(result);
-
-      return {
-        data: result
-      };
-    });
-    return promise;
-  };
-
-  var nodejs = function(key, pdata, props) {
-    if (6 > helpers.nodeCrypto.pbkdf2.length) {
-      throw new Error("unsupported algorithm: PBES2-" + hmac + "+" + kw);
-    }
-
-    props = props || {};
-
-    var salt = util.asBuffer(props.p2s || Buffer.alloc(0), "base64url"),
-        itrs = props.p2c || 0;
-
-    if (0 >= itrs) {
-      throw new Error("invalid iteration count");
-    }
-    if (8 > salt.length) {
-      throw new Error("salt too small");
-    }
-    salt = fixSalt(hmac, kw, salt);
-
-    var promise;
-
-    // STEP 1: derive shared key
-    var hash = hmac.replace("HS", "SHA");
-    promise = new Promise(function(resolve, reject) {
-      function cb(err, dk) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(dk);
-        }
-      }
-      helpers.nodeCrypto.pbkdf2(key, salt, itrs, keyLen, hash, cb);
-    });
-
-    // STEP 2: encrypt cek
-    promise = promise.then(function(dk) {
-      return KW[kw].encrypt(dk, pdata);
+    // STEP 3: (re-)apply headers
+    promise = promise.then(function (results) {
+      results.header = merge(results.header || {}, header);
+      return results;
     });
 
     return promise;
   };
-
-  return helpers.setupFallback(nodejs, webcrypto, fallback);
 }
 
 function pbes2DecryptFN(hmac, kw) {
+  var deriveAlg = "PBKDF2-" + hmac.replace("HS", "SHA-");
   var keyLen = CONSTANTS.KEYLENGTH[kw] / 8;
 
-  var fallback = function(key, cdata, props) {
+  return function(key, cdata, props) {
     props = props || {};
 
     var salt = util.asBuffer(props.p2s || Buffer.alloc(0), "base64url"),
@@ -304,120 +204,18 @@ function pbes2DecryptFN(hmac, kw) {
       return Promise.reject(new Error("salt too small"));
     }
     salt = fixSalt(hmac, kw, salt);
+    props = merge(props, {
+      salt: salt,
+      iterations: itrs,
+      length: keyLen
+    });
 
-    var promise;
+    var promise = Promise.resolve(key);
 
     // STEP 1: derived shared key
-    promise = new Promise(function(resolve, reject) {
-      var md = forge.md[hmac.replace("HS", "SHA").toLowerCase()].create();
-      var cb = function(err, dk) {
-        if (err) {
-          reject(err);
-        } else {
-          dk = Buffer.from(dk, "binary");
-          resolve(dk);
-        }
-      };
-
-      forge.pkcs5.pbkdf2(key.toString("binary"),
-                         salt.toString("binary"),
-                         itrs,
-                         keyLen,
-                         md,
-                         cb);
-    });
-
-    // STEP 2: decrypt cek
-    promise = promise.then(function(dk) {
-      return KW[kw].decrypt(dk, cdata);
-    });
-    return promise;
-  };
-
-  var webcrypto = function(key, cdata, props) {
-    props = props || {};
-
-    var salt = util.asBuffer(props.p2s || Buffer.alloc(0), "base64url"),
-        itrs = props.p2c || 0;
-
-    if (0 >= itrs) {
-      return Promise.reject(new Error("invalid iteration count"));
-    }
-
-    if (8 > salt.length) {
-      return Promise.reject(new Error("salt too small"));
-    }
-    salt = fixSalt(hmac, kw, salt);
-
-    var hash = hmac.replace("HS", "SHA-");
-    var promise;
-    promise = Promise.resolve(key);
-    promise = promise.then(function(keyval) {
-      return helpers.subtleCrypto.importKey("raw", keyval, "PBKDF2", false, ["deriveKey"]);
-    });
     promise = promise.then(function(key) {
-      var mainAlgo = {
-        name: "PBKDF2",
-        salt: salt,
-        iterations: itrs,
-        hash: hash
-      };
-      var deriveAlgo = {
-        name: "AES-KW",
-        length: keyLen * 8
-      };
-
-      return helpers.subtleCrypto.deriveKey(mainAlgo, key, deriveAlgo, true, ["wrapKey", "unwrapKey"]);
+      return pbes2[deriveAlg].derive(key, props);
     });
-    // STEP 2: decrypt cek
-    promise = promise.then(function(key) {
-      return helpers.subtleCrypto.unwrapKey("raw", cdata, key, "AES-KW", {name: "HMAC", hash: "SHA-256"}, true, ["sign"]);
-    });
-    promise = promise.then(function(result) {
-      // unwrapped CryptoKey -- extract raw
-      return helpers.subtleCrypto.exportKey("raw", result);
-    });
-    promise = promise.then(function(result) {
-      result = Buffer.from(result);
-      return result;
-    });
-    return promise;
-  };
-
-  var nodejs = function(key, cdata, props) {
-    if (6 > helpers.nodeCrypto.pbkdf2.length) {
-      throw new Error("unsupported algorithm: PBES2-" + hmac + "+" + kw);
-    }
-
-    props = props || {};
-
-    var salt = util.asBuffer(props.p2s || Buffer.alloc(0), "base64url"),
-        itrs = props.p2c || 0;
-
-    if (0 >= itrs) {
-      return Promise.reject(new Error("invalid iteration count"));
-    }
-
-    if (8 > salt.length) {
-      return Promise.reject(new Error("salt too small"));
-    }
-    salt = fixSalt(hmac, kw, salt);
-
-    var promise;
-
-    // STEP 1: derive shared key
-    var hash = hmac.replace("HS", "SHA");
-    promise = new Promise(function(resolve, reject) {
-      function cb(err, dk) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(dk);
-        }
-      }
-      helpers.nodeCrypto.pbkdf2(key, salt, itrs, keyLen, hash, cb);
-    });
-
     // STEP 2: decrypt cek
     promise = promise.then(function(dk) {
       return KW[kw].decrypt(dk, cdata);
@@ -425,8 +223,6 @@ function pbes2DecryptFN(hmac, kw) {
 
     return promise;
   };
-
-  return helpers.setupFallback(nodejs, webcrypto, fallback);
 }
 
 // ### Public API

--- a/lib/algorithms/pbes2.js
+++ b/lib/algorithms/pbes2.js
@@ -32,21 +32,20 @@ function pbkdf2Fn(hash) {
     var salt = util.asBuffer(props.salt || Buffer.alloc(0), "base64u4l"),
         itrs = props.iterations || 0;
 
-  if (0 >= keyLen) {
-    throw new Error("invalid key length");
+    if (0 >= keyLen) {
+      throw new Error("invalid key length");
+    }
+    if (0 >= itrs) {
+      throw new Error("invalid iteration count");
+    }
+
+    props.length = keyLen;
+    props.salt = salt;
+    props.iterations = itrs;
+
+    return props;
   }
-  if (0 >= itrs) {
-    throw new Error("invalid iteration count");
-  }
 
-  props.length = keyLen;
-  props.salt = salt;
-  props.iterations = itrs;
-
-  return props;
-}
-
-function pbkdf2Fn(hash) {
   var fallback = function(key, props) {
     try {
       props = prepareProps(props);
@@ -96,7 +95,7 @@ function pbkdf2Fn(hash) {
     promise = promise.then(function(key) {
       var mainAlgo = {
         name: "PBKDF2",
-        salt: salt,
+        salt: new Uint8Array(salt),
         iterations: itrs,
         hash: hash
       };
@@ -148,7 +147,7 @@ function pbes2EncryptFN(hmac, kw) {
     props = props || {};
 
     var salt = util.asBuffer(props.p2s || Buffer.alloc(0), "base64url"),
-      itrs = props.p2c || 0;
+      itrs = props.p2c || DEFAULT_ITERATIONS;
 
     if (0 >= itrs) {
       throw new Error("invalid iteration count");

--- a/lib/jwe/encrypt.js
+++ b/lib/jwe/encrypt.js
@@ -460,7 +460,7 @@ function JWEEncrypter(cfg, fields, recipients) {
               if (!rcpt) { return; }
               if (!(f in rcpt)) { return; }
               if (!rcpt[f]) { return; }
-              if (!Object.keys(rcpt[f]).length) { return; }
+              if ("object" === typeof rcpt[f] && !Object.keys(rcpt[f]).length) { return; }
               flattened[f] = rcpt[f];
             });
             if (jwe.aad) {

--- a/lib/jwe/encrypt.js
+++ b/lib/jwe/encrypt.js
@@ -7,6 +7,7 @@
 
 var assign = require("lodash.assign"),
     clone = require("lodash.clone"),
+    omit = require("lodash.omit"),
     util = require("../util"),
     generateCEK = require("./helpers").generateCEK,
     JWK = require("../jwk"),
@@ -181,7 +182,7 @@ function JWEEncrypter(cfg, fields, recipients) {
           // generate Ephemeral EC Key
           var tks,
               rpromise;
-          if (algAlg.indexOf("ECDH-ES") === 0) {
+          if ((props.alg || "").indexOf("ECDH-ES") === 0) {
             tks = algKey.keystore.temp();
             if (r.epk) {
               rpromise = Promise.resolve(r.epk).
@@ -298,7 +299,7 @@ function JWEEncrypter(cfg, fields, recipients) {
         if ((protectAll && jwe.recipients.length === 1) || "compact" === format) {
           // merge single recipient into fields
           protect = {};
-          protect = assign(jwe.recipients[0].header || {},
+          protect = assign({},
                      unprotect,
                     jwe.recipients[0].header);
           lenProtect = Object.keys(protect).length;
@@ -315,6 +316,7 @@ function JWEEncrypter(cfg, fields, recipients) {
           lenProtect = 0;
           lenUnprotect = Object.keys(unprotect).length;
           cfg.protect.forEach(function(f) {
+            // remove protected header values from body unprotected header
             if (!(f in unprotect)) {
               return;
             }
@@ -323,6 +325,20 @@ function JWEEncrypter(cfg, fields, recipients) {
 
             delete unprotect[f];
             lenUnprotect--;
+          });
+
+          jwe.recipients = (jwe.recipients || []).map(function(rcpt) {
+            rcpt = rcpt || {};
+            var header = rcpt.header;
+            if (header) {
+              Object.keys(header).forEach(function (f) {
+                if (f in protect) { delete header[f]; }
+              });
+              if (!Object.keys(header).length) {
+                delete rcpt.header;
+              }
+            }
+            return rcpt;
           });
         }
 
@@ -443,6 +459,8 @@ function JWEEncrypter(cfg, fields, recipients) {
             ["header", "encrypted_key"].forEach(function(f) {
               if (!rcpt) { return; }
               if (!(f in rcpt)) { return; }
+              if (!rcpt[f]) { return; }
+              if (!Object.keys(rcpt[f]).length) { return; }
               flattened[f] = rcpt[f];
             });
             if (jwe.aad) {
@@ -455,6 +473,22 @@ function JWEEncrypter(cfg, fields, recipients) {
             return flattened;
           });
           break;
+        case "general":
+          promise = promise.then(function(jwe) {
+            var recipients = jwe.recipients || [];
+            recipients = recipients.map(function (rcpt) {
+              if (!Object.keys(rcpt).length) { return undefined; }
+              return rcpt;
+            });
+            recipients = recipients.filter(function (rcpt) { return !!rcpt; });
+            if (recipients.length) {
+              jwe.recipients = recipients;
+            } else {
+              delete jwe.recipients;
+            }
+
+            return jwe;
+          });
       }
 
       return promise;
@@ -583,6 +617,7 @@ function createEncrypt(opts, rcpts) {
       // ensure key protection algorithm is set
       if (!props.alg) {
         props.alg = key.algorithms(JWK.MODE_WRAP)[0];
+        header.alg = props.alg;
       }
       if (!props.alg) {
         return Promise.reject(new Error("key not valid for encrypting to recipient " + idx));

--- a/lib/jwe/encrypt.js
+++ b/lib/jwe/encrypt.js
@@ -7,7 +7,6 @@
 
 var assign = require("lodash.assign"),
     clone = require("lodash.clone"),
-    omit = require("lodash.omit"),
     util = require("../util"),
     generateCEK = require("./helpers").generateCEK,
     JWK = require("../jwk"),

--- a/lib/jwe/encrypt.js
+++ b/lib/jwe/encrypt.js
@@ -297,8 +297,10 @@ function JWEEncrypter(cfg, fields, recipients) {
         unprotect = clone(fields);
         if ((protectAll && jwe.recipients.length === 1) || "compact" === format) {
           // merge single recipient into fields
+          protect = {};
           protect = assign(jwe.recipients[0].header || {},
-                     unprotect);
+                     unprotect,
+                    jwe.recipients[0].header);
           lenProtect = Object.keys(protect).length;
 
           unprotect = undefined;

--- a/lib/jwk/octkey.js
+++ b/lib/jwk/octkey.js
@@ -32,6 +32,9 @@ var WRAP_ALGS = [
   "A128KW",
   "A192KW",
   "A256KW",
+  "A128GCMKW",
+  "A192GCMKW",
+  "A256GCMKW",
   "PBES2-HS256+A128KW",
   "PBES2-HS384+A192KW",
   "PBES2-HS512+A256KW",
@@ -144,6 +147,7 @@ var JWKOctetCfg = {
       case "unwrap":
         return WRAP_ALGS.filter(function(a) {
           return (a === ("A" + len + "KW")) ||
+                 (a === ("A" + len + "GCMKW")) ||
                  (a.indexOf("PBES2-") === 0) ||
                  (a === "dir");
         });

--- a/test/algorithms/pbes2-test.js
+++ b/test/algorithms/pbes2-test.js
@@ -112,6 +112,8 @@ describe("algorithms/pbes2", function() {
       var promise = algorithms.encrypt(v.alg, key, pdata, props);
       promise = promise.then(function(result) {
         assert.equal(result.data.toString("hex"), cdata.toString("hex"));
+        assert.equal(result.header.p2s, util.base64url.encode(v.salt));
+        assert.equal(result.header.p2c, v.iterations);
       });
       return promise;
     };
@@ -125,5 +127,10 @@ describe("algorithms/pbes2", function() {
 
     it("performs " + v.alg + " (" + v.desc + ") encryption", encrunner);
     it("performs " + v.alg + " (" + v.desc + ") decryption", decrunner);
+  });
+
+  it("applies a default iteration count when missing", function() {
+  });
+  it("applies a valid salt when missing", function() {
   });
 });

--- a/test/jwe/implicit-header-test.js
+++ b/test/jwe/implicit-header-test.js
@@ -1,0 +1,116 @@
+/*!
+ *
+ * Copyright (c) 2016 Cisco Systems, Inc. See LICENSE file.
+ */
+"use strict";
+
+var chai = require("chai");
+
+var JWK = require("../../lib/jwk");
+var JWE = require("../../lib/jwe");
+var util = require("../../lib/util");
+
+var assert = chai.assert;
+
+describe("jwe/implicit-headers", function() {
+  var plaintext = "Well, I'm back.";
+  var opts = {
+    format: "compact"
+  };
+
+  describe("AES-GCM-KW", function() {
+    var key = {
+      "kty": "oct",
+          "kid": "ojk4tyByIC1BaxTrVO0cYHaabiMZNk6MqPOLTScNQtE",
+          "alg": "A256GCMKW",
+          "k": "7tQn3vrNh3U9X44AO5Day_eSrms9WnV0cKel6oGljWE"
+        };
+
+    before(function() {
+      return JWK.asKey(key).then(function(jwk) { key = jwk; });
+    });
+
+    it("adds a missing iv", function() {
+      var p;
+      p = JWE.createEncrypt(opts, key).final(plaintext, "utf8");
+      p = p.then(function(result) {
+        var header = result.split(".")[0];
+        header = JSON.parse(util.base64url.decode(header).toString());
+        assert.ok(header.iv);
+        assert.ok(header.tag);
+        assert.equal(util.base64url.decode(header.iv).length, 12);
+        assert.equal(util.base64url.decode(header.tag).length, 16);
+
+        return JWE.createDecrypt(key).decrypt(result);
+      });
+      p = p.then(function(result) {
+        assert.deepEqual(result.payload.toString(), plaintext);
+      });
+      return p;
+    });
+  });
+
+  describe("PBES2", function() {
+    var key,
+        pwd = "keep it secret! Keep it safe!",
+        salt = util.base64url.encode("b86f66a68307d5f99b255790db605a3b", "utf8"),
+        itrs = 12288;
+
+    before(function() {
+      return JWK.asKey({
+        kty: "oct",
+        k: util.base64url.encode(Buffer.from(pwd, "utf8")),
+        alg: "PBES2-HS512+A256KW"
+      }).then(function(jwk) { key = jwk; });
+    });
+
+    it("adds a missing salt", function() {
+      var recipient = {
+        key: key,
+        header: {
+          p2c: itrs
+        }
+      };
+      var p;
+      p = JWE.createEncrypt(opts, recipient).final(plaintext, "utf8");
+      p = p.then(function(result) {
+        var header = result.split(".")[0];
+        header = JSON.parse(util.base64url.decode(header).toString());
+        assert.ok(header.p2s);
+        assert.ok(header.p2c);
+        assert.typeOf(header.p2s, "string");
+        assert.equal(header.p2c, itrs);
+
+        return JWE.createDecrypt(key).decrypt(result);
+      });
+      p = p.then(function (result) {
+        assert.deepEqual(result.payload.toString(), plaintext);
+      });
+      return p;
+    });
+    it("adds a missing iteration count", function() {
+      var recipient = {
+        key: key,
+        header: {
+          p2s: salt
+        }
+      };
+      var p;
+      p = JWE.createEncrypt(opts, recipient).final(plaintext, "utf8");
+      p = p.then(function (result) {
+        var header = result.split(".")[0];
+        header = JSON.parse(util.base64url.decode(header).toString());
+        assert.ok(header.p2s);
+        assert.ok(header.p2c);
+        assert.equal(header.p2s, salt);
+        assert.equal(header.p2c, 8192);
+
+        return JWE.createDecrypt(key).decrypt(result);
+      });
+      p = p.then(function (result) {
+        assert.deepEqual(result.payload.toString(), plaintext);
+      });
+      return p;
+    });
+  });
+});

--- a/test/jwe/jwe-test.js
+++ b/test/jwe/jwe-test.js
@@ -19,14 +19,16 @@ var fixtures = {
   "5_3.key_wrap_using_pbes2-aes-keywrap_with-aes-cbc-hmac-sha2": cloneDeep(require("jose-cookbook/jwe/5_3.key_wrap_using_pbes2-aes-keywrap_with-aes-cbc-hmac-sha2.json")),
   "5_4.key_agreement_with_key_wrapping_using_ecdh-es_and_aes-keywrap_with_aes-gcm": cloneDeep(require("jose-cookbook/jwe/5_4.key_agreement_with_key_wrapping_using_ecdh-es_and_aes-keywrap_with_aes-gcm.json")),
   "5_5.key_agreement_using_ecdh-es_with_aes-cbc-hmac-sha2": cloneDeep(require("jose-cookbook/jwe/5_5.key_agreement_using_ecdh-es_with_aes-cbc-hmac-sha2.json")),
-  "5_7.key_wrap_using_aes-gcm_keywrap_with_aes-cbc-hmac-sha2.json": cloneDeep(require("jose-cookbook/jwe/5_7.key_wrap_using_aes-gcm_keywrap_with_aes-cbc-hmac-sha2.json")),
   "5_6.direct_encryption_using_aes-gcm": cloneDeep(require("jose-cookbook/jwe/5_6.direct_encryption_using_aes-gcm.json")),
+  "5_7.key_wrap_using_aes-gcm_keywrap_with_aes-cbc-hmac-sha2.json": cloneDeep(require("jose-cookbook/jwe/5_7.key_wrap_using_aes-gcm_keywrap_with_aes-cbc-hmac-sha2.json")),
   "5_8.key_wrap_using_aes-keywrap_with_aes-gcm": cloneDeep(require("jose-cookbook/jwe/5_8.key_wrap_using_aes-keywrap_with_aes-gcm.json")),
   "5_9.compressed_content": cloneDeep(require("jose-cookbook/jwe/5_9.compressed_content.json")),
   "5_10.including_additional_authentication_data": cloneDeep(require("jose-cookbook/jwe/5_10.including_additional_authentication_data.json"))
+  /*
+  //*/
 };
 
-describe.only("jwe", function() {
+describe("jwe", function() {
   forEach(fixtures, function(fixture) {
     var input = fixture.input;
     var generated = fixture.generated;
@@ -81,7 +83,7 @@ describe.only("jwe", function() {
             var options = {
               compact: true,
               contentAlg: input.enc,
-              protect: "*",
+              protect: Object.keys(encrypting.protected),
               iv: generated.iv,
               fields: encrypting.protected
             };
@@ -107,7 +109,7 @@ describe.only("jwe", function() {
             var options = {
               compact: false,
               contentAlg: input.enc,
-              protect: "*",
+              protect: Object.keys(encrypting.protected),
               iv: generated.iv,
               fields: encrypting.protected
             };
@@ -133,7 +135,7 @@ describe.only("jwe", function() {
             var options = {
               format: "flattened",
               contentAlg: input.enc,
-              protect: "*",
+              protect: Object.keys(encrypting.protected),
               iv: generated.iv,
               fields: encrypting.protected
             };

--- a/test/jwe/jwe-test.js
+++ b/test/jwe/jwe-test.js
@@ -19,13 +19,14 @@ var fixtures = {
   "5_3.key_wrap_using_pbes2-aes-keywrap_with-aes-cbc-hmac-sha2": cloneDeep(require("jose-cookbook/jwe/5_3.key_wrap_using_pbes2-aes-keywrap_with-aes-cbc-hmac-sha2.json")),
   "5_4.key_agreement_with_key_wrapping_using_ecdh-es_and_aes-keywrap_with_aes-gcm": cloneDeep(require("jose-cookbook/jwe/5_4.key_agreement_with_key_wrapping_using_ecdh-es_and_aes-keywrap_with_aes-gcm.json")),
   "5_5.key_agreement_using_ecdh-es_with_aes-cbc-hmac-sha2": cloneDeep(require("jose-cookbook/jwe/5_5.key_agreement_using_ecdh-es_with_aes-cbc-hmac-sha2.json")),
+  "5_7.key_wrap_using_aes-gcm_keywrap_with_aes-cbc-hmac-sha2.json": cloneDeep(require("jose-cookbook/jwe/5_7.key_wrap_using_aes-gcm_keywrap_with_aes-cbc-hmac-sha2.json")),
   "5_6.direct_encryption_using_aes-gcm": cloneDeep(require("jose-cookbook/jwe/5_6.direct_encryption_using_aes-gcm.json")),
   "5_8.key_wrap_using_aes-keywrap_with_aes-gcm": cloneDeep(require("jose-cookbook/jwe/5_8.key_wrap_using_aes-keywrap_with_aes-gcm.json")),
   "5_9.compressed_content": cloneDeep(require("jose-cookbook/jwe/5_9.compressed_content.json")),
   "5_10.including_additional_authentication_data": cloneDeep(require("jose-cookbook/jwe/5_10.including_additional_authentication_data.json"))
 };
 
-describe("jwe", function() {
+describe.only("jwe", function() {
   forEach(fixtures, function(fixture) {
     var input = fixture.input;
     var generated = fixture.generated;

--- a/test/jwk/octkey-test.js
+++ b/test/jwk/octkey-test.js
@@ -506,9 +506,9 @@ describe("jwk/oct", function() {
       assert.deepEqual(algs, ["A128GCM"]);
 
       algs = JWK.OCTET.config.algorithms(keys, "wrap");
-      assert.deepEqual(algs, ["A128KW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
+      assert.deepEqual(algs, ["A128KW", "A128GCMKW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
       algs = JWK.OCTET.config.algorithms(keys, "unwrap");
-      assert.deepEqual(algs, ["A128KW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
+      assert.deepEqual(algs, ["A128KW", "A128GCMKW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
     });
     it("returns the suite for 192-bit", function() {
       var keys = generateKeys(192);
@@ -525,9 +525,9 @@ describe("jwk/oct", function() {
       assert.deepEqual(algs, ["A192GCM"]);
 
       algs = JWK.OCTET.config.algorithms(keys, "wrap");
-      assert.deepEqual(algs, ["A192KW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
+      assert.deepEqual(algs, ["A192KW", "A192GCMKW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
       algs = JWK.OCTET.config.algorithms(keys, "unwrap");
-      assert.deepEqual(algs, ["A192KW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
+      assert.deepEqual(algs, ["A192KW", "A192GCMKW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
     });
     it("returns the suite for 256-bit", function() {
       var keys = generateKeys(256);
@@ -544,9 +544,9 @@ describe("jwk/oct", function() {
       assert.deepEqual(algs, ["A256GCM", "A128CBC-HS256", "A128CBC+HS256"]);
 
       algs = JWK.OCTET.config.algorithms(keys, "wrap");
-      assert.deepEqual(algs, ["A256KW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
+      assert.deepEqual(algs, ["A256KW", "A256GCMKW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
       algs = JWK.OCTET.config.algorithms(keys, "unwrap");
-      assert.deepEqual(algs, ["A256KW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
+      assert.deepEqual(algs, ["A256KW", "A256GCMKW", "PBES2-HS256+A128KW", "PBES2-HS384+A192KW", "PBES2-HS512+A256KW", "dir"]);
     });
     it("returns the suite for 384-bit", function() {
       var keys = generateKeys(384);


### PR DESCRIPTION
Closes #133 

When wrapping keys in JWE, the algorithm can generate a missing value and it'll be applied to the JWE header(s).

For `A*GCMKW`:
* generate `"iv"` of 12 random bytes

For `PBES2-*`:
* generate `"p2s"` of 16 random bytes
* apply `"p2c"` of 8192