### PR TITLE
fix: use native node crypto instead of forge for RS\d{3}

### DIFF
--- a/lib/algorithms/rsa-util.js
+++ b/lib/algorithms/rsa-util.js
@@ -51,8 +51,9 @@ function convertToJWK(key, isPublic) {
 }
 
 function convertToPem(key, isPublic) {
-  if (key.__cachedPem) {
-    return key.__cachedPem;
+  var cacheKey = isPublic ? `__cachedPublicPem` : `__cachedPrivatePem`;
+  if (key[cacheKey]) {
+    return key[cacheKey];
   }
 
   var value;
@@ -62,7 +63,7 @@ function convertToPem(key, isPublic) {
     value = forge.pki.privateKeyToPem(convertToForge(key, isPublic));
   }
 
-  Object.defineProperty(key, '__cachedPem', { value: value });
+  Object.defineProperty(key, cacheKey, { value: value });
   return value;
 }
 

--- a/lib/algorithms/rsaes.js
+++ b/lib/algorithms/rsaes.js
@@ -1,5 +1,5 @@
 /*!
- * algorithms/rsassa.js - RSA Signatures
+ * algorithms/rsaes.js - RSA Signatures
  *
  * Copyright (c) 2015 Cisco Systems, Inc.  See LICENSE file.
  */

--- a/lib/algorithms/rsassa.js
+++ b/lib/algorithms/rsassa.js
@@ -61,15 +61,16 @@ function rsassaV15SignFn(name) {
   };
 
   var nodejs;
-  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(hash) > -1) {
+  var nodeHash = "RSA-" + hash.replace("-", "");
+  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(nodeHash) > -1) {
     nodejs = function(key, pdata) {
       key = rsaUtil.convertToPem(key, false);
-      var sign = helpers.nodeCrypto.createSign(hash);
+      var sign = helpers.nodeCrypto.createSign(nodeHash);
       sign.update(pdata);
 
       return {
         data: pdata,
-        mac: sign.sign(rsaUtil.convertToPem(key, false))
+        mac: sign.sign(key)
       };
     };
   }


### PR DESCRIPTION
See
```
node -e 'console.log(crypto.getHashes())' | grep 'RSA-SHA'
```
The hash name passed in was wrong and native crypto was never used.

Furthermore rsa-util convertToPem now caches public/private separately, else the tests that reuse the same key object and call the method once true then false were failing.