### PR TITLE
fix test assertion that would get ignored

### DIFF
--- a/test/jwe/crit-test.js
+++ b/test/jwe/crit-test.js
@@ -36,8 +36,7 @@ describe("jwe/crit", function() {
              decrypt(jwe).
              then(function() {
                assert.ok(false, "unexpected success");
-             }).
-             catch(function(err) {
+             }, function(err) {
                assert.ok(err instanceof Error);
              });
     });

--- a/test/jws/crit-test.js
+++ b/test/jws/crit-test.js
@@ -35,8 +35,7 @@ describe("jws/crit", function() {
              verify(jws).
              then(function() {
                assert.ok(false, "unexpected success");
-             }).
-             catch(function(err) {
+             }, function(err) {
                assert.ok(err instanceof Error);
              });
     });


### PR DESCRIPTION
If the line `assert.ok(false, "unexpected success");` would throw, then it would get caught in the catch function. By moving the catch function to the second argument of `then` as opposed to a chained `catch` method call, it ensures that only errors from `decrypt(jwe)` will get caught.

> I just noticed this while skimming through the tests to get a better understanding of the module. Apologies if I'm wrong about the bug.