### PR TITLE
make more use of node crypto + more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,17 @@ addons:
     packages:
     - g++-4.8
 node_js:
-- '6'
-- '7'
-- '8'
-- '9'
-- '10'
+- 6.0.0 # min
+- lts/boron
+- 8.0.0
+- lts/carbon
+- stable
 env:
   matrix:
   - CXX=g++-4.8 TASKS=test:nodejs
 matrix:
   include:
-  - node_js: 10
+  - node_js: stable
     env:
     - CXX=g++-4.8 TASKS=travis:browser MOZ_HEADLESS=1
     addons:

--- a/lib/algorithms/aes-kw.js
+++ b/lib/algorithms/aes-kw.js
@@ -122,8 +122,40 @@ function kwEncryptFN(size) {
     });
     return promise;
   };
+  var node = function(key, pdata) {
+    try {
+      commonChecks(key, pdata);
+    } catch (err) {
+      return Promise.reject(err);
+    }
 
-  return helpers.setupFallback(null, webcrypto, fallback);
+    // split input into chunks
+    var R = split(pdata, 8),
+        iv = Buffer.alloc(16);
+    var A,
+        B,
+        count;
+    A = A0;
+    for (var jdx = 0; 6 > jdx; jdx++) {
+      for (var idx = 0; R.length > idx; idx++) {
+        count = (R.length * jdx) + idx + 1;
+        B = Buffer.concat([A, R[idx]]);
+        var cipher = helpers.nodeCrypto.createCipheriv("AES" + size, key, iv);
+        B = cipher.update(B);
+
+        A = xor(B.slice(0, 8),
+                longToBigEndian(count));
+        R[idx] = B.slice(8, 16);
+      }
+    }
+    R = [A].concat(R);
+    var cdata = Buffer.concat(R);
+    return Promise.resolve({
+      data: cdata
+    });
+  };
+
+  return helpers.setupFallback(node, webcrypto, fallback);
 }
 function kwDecryptFN(size) {
   function commonChecks(key, data) {
@@ -199,8 +231,42 @@ function kwDecryptFN(size) {
     });
     return promise;
   };
+  var node = function(key, cdata) {
+    try {
+      commonChecks(key, cdata);
+    } catch (err) {
+      return Promise.reject(err);
+    }
 
-  return helpers.setupFallback(null, webcrypto, fallback);
+    // prepare inputs
+    var R = split(cdata, 8),
+        iv = Buffer.alloc(16),
+        A,
+        B,
+        count;
+    A = R[0];
+    R = R.slice(1);
+    for (var jdx = 5; 0 <= jdx; --jdx) {
+      for (var idx = R.length - 1; 0 <= idx; --idx) {
+        count = (R.length * jdx) + idx + 1;
+        B = xor(A,
+                longToBigEndian(count));
+        B = Buffer.concat([B, R[idx], iv]);
+        var cipher = helpers.nodeCrypto.createDecipheriv("AES" + size, key, iv);
+        B = cipher.update(B);
+
+        A = B.slice(0, 8);
+        R[idx] = B.slice(8, 16);
+      }
+    }
+    if (A.toString() !== A0.toString()) {
+      return Promise.reject(new Error("decryption failed"));
+    }
+    var pdata = Buffer.concat(R);
+    return Promise.resolve(pdata);
+  };
+
+  return helpers.setupFallback(node, webcrypto, fallback);
 }
 
 // ### Public API

--- a/lib/algorithms/ec-util.js
+++ b/lib/algorithms/ec-util.js
@@ -78,10 +78,183 @@ function curveSize(crv) {
   return EC_KEYSIZES[crv || ""] || NaN;
 }
 
+function curveNameToOid(crv) {
+  switch (crv) {
+    case "P-256":
+      return "1.2.840.10045.3.1.7";
+    case "P-384":
+      return "1.3.132.0.34";
+    case "P-521":
+      return "1.3.132.0.35";
+    default:
+      return null;
+  }
+}
+
+var EC_OID = "1.2.840.10045.2.1";
+function convertToPEM(key, isPrivate) {
+  // curveName to OID
+  var oid = key.crv;
+  oid = curveNameToOid(oid);
+  oid = forge.asn1.oidToDer(oid);
+  // key as bytes
+  var type,
+      pub,
+      asn1;
+  if (isPrivate) {
+    type = "EC PRIVATE KEY";
+    pub = Buffer.concat([
+      Buffer.from([0x00, 0x04]),
+      key.x,
+      key.y
+    ]).toString("binary");
+    key = key.d.toString("binary");
+    asn1 = forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [
+      forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.INTEGER, false, "\u0001"),
+      forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OCTETSTRING, false, key),
+      forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 0, true, [
+        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OID, false, oid.bytes())
+      ]),
+      forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 1, true, [
+        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.BITSTRING, false, pub)
+      ])
+    ]);
+  } else {
+    type = "PUBLIC KEY";
+    key = Buffer.concat([
+      Buffer.from([0x00, 0x04]),
+      key.x,
+      key.y
+    ]).toString("binary");
+    asn1 = forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [
+      forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [
+        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OID, false, forge.asn1.oidToDer(EC_OID).bytes()),
+        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OID, false, oid.bytes())
+      ]),
+      forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.BITSTRING, false, key)
+    ]);
+  }
+  asn1 = forge.asn1.toDer(asn1).bytes();
+  var pem = forge.pem.encode({
+    type: type,
+    body: asn1
+  });
+  return pem;
+}
+
+// Inspired by teifip/node-webtokens/blob/master/lib/ecdsa.js
+var ERR_MSG = 'Could not extract parameters from DER signature';
+function derToConcat(signature, size) {
+  var offset = 0;
+  if (signature[offset++] !== 0x30) {
+    throw new Error(ERR_MSG);
+  }
+  var seqLength = signature[offset++];
+  if (seqLength === 0x81) {
+    seqLength = signature[offset++];
+  }
+  if (seqLength > signature.length - offset) {
+    throw new Error(ERR_MSG);
+  }
+  if (signature[offset++] !== 0x02) {
+    throw new Error(ERR_MSG);
+  }
+  var rLength = signature[offset++];
+  if (rLength > signature.length - offset - 2) {
+    throw new Error(ERR_MSG);
+  }
+  if (rLength > size + 1) {
+    throw new Error(ERR_MSG);
+  }
+  var rOffset = offset;
+  offset += rLength;
+  if (signature[offset++] !== 0x02) {
+    throw new Error(ERR_MSG);
+  }
+  var sLength = signature[offset++];
+  if (sLength !== signature.length - offset) {
+    throw new Error(ERR_MSG);
+  }
+  if (sLength > size + 1) {
+    throw new Error(ERR_MSG);
+  }
+  var sOffset = offset;
+  offset += sLength;
+  if (offset !== signature.length) {
+    throw new Error(ERR_MSG);
+  }
+  var rPadding = size - rLength;
+  var sPadding = size - sLength;
+  var dst = Buffer.alloc(rPadding + rLength + sPadding + sLength);
+  for (offset = 0; offset < rPadding; ++offset) {
+    dst[offset] = 0;
+  }
+  var rPad = Math.max(-rPadding, 0);
+  signature.copy(dst, offset, rOffset + rPad, rOffset + rLength);
+  offset = size;
+  for (var o = offset; offset < o + sPadding; ++offset) {
+    dst[offset] = 0;
+  }
+  var sPad = Math.max(-sPadding, 0);
+  signature.copy(dst, offset, sOffset + sPad, sOffset + sLength);
+  return dst;
+}
+
+function countPadding(buf, start, stop) {
+  var padding = 0;
+  while (start + padding < stop && buf[start + padding] === 0) {
+    ++padding;
+  }
+  var needsSign = buf[start + padding] >= 0x80;
+  if (needsSign) {
+    --padding;
+  }
+  return padding;
+}
+
+function concatToDer(signature, size) {
+  var rPadding = countPadding(signature, 0, size);
+  var sPadding = countPadding(signature, size, signature.length);
+  var rLength = size - rPadding;
+  var sLength = size - sPadding;
+  var rsBytes = rLength + sLength + 4;
+  var shortLength = rsBytes < 0x80;
+  var dst = Buffer.alloc((shortLength ? 2 : 3) + rsBytes);
+  var offset = 0;
+  dst[offset++] = 0x30;
+  if (shortLength) {
+    dst[offset++] = rsBytes;
+  } else {
+    dst[offset++] = 0x81;
+    dst[offset++] = rsBytes & 0xFF;
+  }
+  dst[offset++] = 0x02;
+  dst[offset++] = rLength;
+  if (rPadding < 0) {
+    dst[offset++] = 0;
+    offset += signature.copy(dst, offset, 0, size);
+  } else {
+    offset += signature.copy(dst, offset, rPadding, size);
+  }
+  dst[offset++] = 0x02;
+  dst[offset++] = sLength;
+  if (sPadding < 0) {
+    dst[offset++] = 0;
+    signature.copy(dst, offset, size);
+  } else {
+    signature.copy(dst, offset, size + sPadding);
+  }
+  return dst;
+}
+
 module.exports = {
   convertToForge: convertToForge,
   convertToJWK: convertToJWK,
   convertToObj: convertToObj,
   convertToBuffer: convertToBuffer,
-  curveSize: curveSize
+  curveSize: curveSize,
+  derToConcat: derToConcat,
+  concatToDer: concatToDer,
+  convertToPEM: convertToPEM,
+  EC_OID: EC_OID
 };

--- a/lib/algorithms/ecdsa.js
+++ b/lib/algorithms/ecdsa.js
@@ -80,7 +80,50 @@ function ecdsaSignFN(hash) {
     return promise;
   };
 
-  return helpers.setupFallback(null, webcrypto, fallback);
+  var nodejs;
+  var nodeHash = hash.toLowerCase().replace("-", "");
+  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(nodeHash) > -1) {
+    nodejs = function(key, pdata) {
+      if (curve !== key.crv) {
+        return Promise.reject(new Error("invalid curve"));
+      }
+
+      var promise;
+      promise = Promise.resolve(helpers.nodeCrypto.createSign(nodeHash));
+      promise = promise.then(function (sign) {
+        sign.update(pdata);
+        return sign;
+      });
+
+      var size;
+
+      switch (nodeHash.slice(-3)) {
+        case "384":
+          size = 48;
+          break;
+        case "512":
+          size = 66;
+          break;
+        default:
+          size = 32;
+      }
+
+      promise = promise.then(function (sign) {
+        return ecUtil.derToConcat(sign.sign(ecUtil.convertToPEM(key, true)), size);
+      });
+
+      promise = promise.then(function (result) {
+        return {
+          data: pdata,
+          mac: result
+        };
+      });
+
+      return promise;
+    };
+  }
+
+  return helpers.setupFallback(nodejs, webcrypto, fallback);
 }
 
 function ecdsaVerifyFN(hash) {
@@ -151,7 +194,49 @@ function ecdsaVerifyFN(hash) {
     return promise;
   };
 
-  return helpers.setupFallback(null, webcrypto, fallback);
+  var nodejs;
+  var nodeHash = hash.toLowerCase().replace("-", "");
+  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(nodeHash) > -1) {
+    nodejs = function(key, pdata, mac /* , props */) {
+      if (curve !== key.crv) {
+        return Promise.reject(new Error("invalid curve"));
+      }
+
+      var size;
+      switch (nodeHash.slice(-3)) {
+        case "384":
+          size = 48;
+          break;
+        case "512":
+          size = 66;
+          break;
+        default:
+          size = 32;
+      }
+
+      var promise;
+      promise = Promise.resolve(helpers.nodeCrypto.createVerify(nodeHash));
+      promise = promise.then(function (verify) {
+        verify.update(pdata);
+        verify.end();
+        return verify.verify(ecUtil.convertToPEM(key, false), ecUtil.concatToDer(mac, size));
+      });
+      promise = promise.then(function (result) {
+        if (!result) {
+          throw new Error('verification failed');
+        }
+        return {
+          data: pdata,
+          mac,
+          valid: true,
+        };
+      });
+
+      return promise;
+    };
+  }
+
+  return helpers.setupFallback(nodejs, webcrypto, fallback);
 }
 
 // ### Public API

--- a/lib/algorithms/rsa-util.js
+++ b/lib/algorithms/rsa-util.js
@@ -51,8 +51,9 @@ function convertToJWK(key, isPublic) {
 }
 
 function convertToPem(key, isPublic) {
-  if (key.__cachedPem) {
-    return key.__cachedPem;
+  var cacheKey = isPublic ? `__cachedPublicPem` : `__cachedPrivatePem`;
+  if (key[cacheKey]) {
+    return key[cacheKey];
   }
 
   var value;
@@ -62,7 +63,7 @@ function convertToPem(key, isPublic) {
     value = forge.pki.privateKeyToPem(convertToForge(key, isPublic));
   }
 
-  Object.defineProperty(key, '__cachedPem', { value: value });
+  Object.defineProperty(key, cacheKey, { value: value });
   return value;
 }
 

--- a/lib/algorithms/rsaes.js
+++ b/lib/algorithms/rsaes.js
@@ -15,6 +15,10 @@ var nodeSupport = {
   RSA1_5: 'RSA_PKCS1_PADDING',
 };
 
+function nodeSupportCheck(name) {
+  return helpers.nodeCrypto && helpers.nodeCrypto.constants && Object.keys(nodeSupport).indexOf(name) !== -1;
+}
+
 // ### RSAES-PKCS1-v1_5
 
 // ### RSAES-OAEP
@@ -82,7 +86,7 @@ function rsaesEncryptFn(name) {
   }
 
   var nodejs;
-  if (helpers.nodeCrypto && Object.keys(nodeSupport).indexOf(name) !== -1) {
+  if (nodeSupportCheck(name)) {
     nodejs = function (key, pdata) {
       key = rsaUtil.convertToPem(key, true);
 
@@ -160,13 +164,18 @@ function rsaesDecryptFn(name) {
   }
 
   var nodejs;
-  if (helpers.nodeCrypto && Object.keys(nodeSupport).indexOf(name) !== -1) { // node does not support RSA-OAEP-256
+  if (nodeSupportCheck(name)) { // node ^6.12.0 || >= 8.0.0
     nodejs = function(key, pdata) {
       key = rsaUtil.convertToPem(key, false);
       return helpers.nodeCrypto.privateDecrypt({
         key,
         padding: helpers.nodeCrypto.constants[nodeSupport[name]],
       }, pdata);
+    };
+  } else if (helpers.nodeCrypto && name === 'RSA-OAEP') { // node (>= 6.0.0 && < 6.12.0) || ^7.0.0
+    nodejs = function(key, pdata) {
+      key = rsaUtil.convertToPem(key, false);
+      return helpers.nodeCrypto.privateDecrypt(key, pdata);
     };
   }
 

--- a/lib/algorithms/rsaes.js
+++ b/lib/algorithms/rsaes.js
@@ -1,5 +1,5 @@
 /*!
- * algorithms/rsassa.js - RSA Signatures
+ * algorithms/rsaes.js - RSA Signatures
  *
  * Copyright (c) 2015 Cisco Systems, Inc.  See LICENSE file.
  */

--- a/lib/algorithms/rsaes.js
+++ b/lib/algorithms/rsaes.js
@@ -160,10 +160,13 @@ function rsaesDecryptFn(name) {
   }
 
   var nodejs;
-  if (helpers.nodeCrypto && name === "RSA-OAEP") { // node only support SHA1, plain RSA-OAEP
+  if (helpers.nodeCrypto && Object.keys(nodeSupport).indexOf(name) !== -1) { // node does not support RSA-OAEP-256
     nodejs = function(key, pdata) {
       key = rsaUtil.convertToPem(key, false);
-      return helpers.nodeCrypto.privateDecrypt(key, pdata);
+      return helpers.nodeCrypto.privateDecrypt({
+        key,
+        padding: helpers.nodeCrypto.constants[nodeSupport[name]],
+      }, pdata);
     };
   }
 

--- a/lib/algorithms/rsaes.js
+++ b/lib/algorithms/rsaes.js
@@ -10,6 +10,11 @@ var forge = require("../deps/forge.js"),
     DataBuffer = require("../util/databuffer.js"),
     rsaUtil = require("./rsa-util.js");
 
+var nodeSupport = {
+  'RSA-OAEP': 'RSA_PKCS1_OAEP_PADDING',
+  RSA1_5: 'RSA_PKCS1_PADDING',
+};
+
 // ### RSAES-PKCS1-v1_5
 
 // ### RSAES-OAEP
@@ -76,7 +81,23 @@ function rsaesEncryptFn(name) {
     webcrypto = null;
   }
 
-  return helpers.setupFallback(null, webcrypto, fallback);
+  var nodejs;
+  if (helpers.nodeCrypto && Object.keys(nodeSupport).indexOf(name) !== -1) {
+    nodejs = function (key, pdata) {
+      key = rsaUtil.convertToPem(key, true);
+
+      var cdata = helpers.nodeCrypto.publicEncrypt({
+        key,
+        padding: helpers.nodeCrypto.constants[nodeSupport[name]],
+      }, pdata);
+
+      return {
+        data: cdata,
+      };
+    };
+  }
+
+  return helpers.setupFallback(nodejs, webcrypto, fallback);
 }
 
 function rsaesDecryptFn(name) {

--- a/lib/algorithms/rsassa.js
+++ b/lib/algorithms/rsassa.js
@@ -10,6 +10,10 @@ var forge = require("../deps/forge.js"),
     helpers = require("./helpers.js"),
     rsaUtil = require("./rsa-util.js");
 
+function nodePSSsupport() {
+  return helpers.nodeCrypto && helpers.nodeCrypto.constants && helpers.nodeCrypto.constants.RSA_PSS_SALTLEN_DIGEST;
+}
+
 // ### RSASSA-PKCS1-v1_5
 
 function rsassaV15SignFn(name) {
@@ -213,7 +217,7 @@ function rsassaPssSignFn(name) {
 
   var nodejs;
   var nodeHash = "RSA-" + hash.replace("-", "");
-  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(nodeHash) > -1) {
+  if (nodePSSsupport()) {
     nodejs = function(key, pdata) {
       var sign = helpers.nodeCrypto.createSign(nodeHash);
       sign.update(pdata);
@@ -299,7 +303,7 @@ function rsassaPssVerifyFn(name) {
   };
 
   var nodejs;
-  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(md) > -1) {
+  if (nodePSSsupport()) {
     nodejs = function(key, pdata, mac) {
       var verify = helpers.nodeCrypto.createVerify(md);
       verify.update(pdata);

--- a/lib/algorithms/rsassa.js
+++ b/lib/algorithms/rsassa.js
@@ -211,7 +211,27 @@ function rsassaPssSignFn(name) {
     return promise;
   };
 
-  return helpers.setupFallback(null, webcrypto, fallback);
+  var nodejs;
+  var nodeHash = "RSA-" + hash.replace("-", "");
+  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(nodeHash) > -1) {
+    nodejs = function(key, pdata) {
+      var sign = helpers.nodeCrypto.createSign(nodeHash);
+      sign.update(pdata);
+
+      var sig = sign.sign({
+        key: rsaUtil.convertToPem(key, false),
+        padding: helpers.nodeCrypto.constants.RSA_PKCS1_PSS_PADDING,
+        saltLength: helpers.nodeCrypto.constants.RSA_PSS_SALTLEN_DIGEST,
+      });
+
+      return {
+        data: pdata,
+        mac: sig
+      };
+    };
+  }
+
+  return helpers.setupFallback(nodejs, webcrypto, fallback);
 }
 
 function rsassaPssVerifyFn(name) {
@@ -278,7 +298,29 @@ function rsassaPssVerifyFn(name) {
     return promise;
   };
 
-  return helpers.setupFallback(null, webcrypto, fallback);
+  var nodejs;
+  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(md) > -1) {
+    nodejs = function(key, pdata, mac) {
+      var verify = helpers.nodeCrypto.createVerify(md);
+      verify.update(pdata);
+      verify.end();
+      var result = verify.verify({
+        key: rsaUtil.convertToPem(key, true),
+        padding: helpers.nodeCrypto.constants.RSA_PKCS1_PSS_PADDING,
+      }, mac);
+      if (!result) {
+        return Promise.reject(new Error("verification failed"));
+      }
+
+      return {
+        data: pdata,
+        mac: mac,
+        valid: true,
+      };
+    };
+  }
+
+  return helpers.setupFallback(nodejs, webcrypto, fallback);
 }
 
 // ### Public API

--- a/lib/algorithms/rsassa.js
+++ b/lib/algorithms/rsassa.js
@@ -61,10 +61,10 @@ function rsassaV15SignFn(name) {
   };
 
   var nodejs;
-  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(hash) > -1) {
+  var nodeHash = "RSA-" + hash.replace("-", "");
+  if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(nodeHash) > -1) {
     nodejs = function(key, pdata) {
-      key = rsaUtil.convertToPem(key, false);
-      var sign = helpers.nodeCrypto.createSign(hash);
+      var sign = helpers.nodeCrypto.createSign(nodeHash);
       sign.update(pdata);
 
       return {

--- a/lib/deps/forge.js
+++ b/lib/deps/forge.js
@@ -88,11 +88,4 @@ modeRaw.prototype.decrypt = function(input, output, finish) {
   forge.cipher.registerAlgorithm(name, factory);
 })();
 
-// Prevent nextTick from being used when possible
-if ("function" === typeof setImmediate) {
-  forge.util.setImmediate = forge.util.nextTick = function(callback) {
-    setImmediate(callback);
-  };
-}
-
 module.exports = forge;

--- a/lib/jwk/eckey.js
+++ b/lib/jwk/eckey.js
@@ -26,7 +26,7 @@ var WRAP_ALGS = [
   "ECDH-ES+A256KW"
 ];
 
-var EC_OID = "1.2.840.10045.2.1";
+var EC_OID = ecutil.EC_OID;
 function oidToCurveName(oid) {
   switch (oid) {
     case "1.2.840.10045.3.1.7":
@@ -35,18 +35,6 @@ function oidToCurveName(oid) {
       return "P-384";
     case "1.3.132.0.35":
       return "P-521";
-    default:
-      return null;
-  }
-}
-function curveNameToOid(crv) {
-  switch (crv) {
-    case "P-256":
-      return "1.2.840.10045.3.1.7";
-    case "P-384":
-      return "1.3.132.0.34";
-    case "P-521":
-      return "1.3.132.0.35";
     default:
       return null;
   }
@@ -151,58 +139,9 @@ var JWKEcCfg = {
   },
   verifyKey: function(alg, keys) {
     return keys.public;
-  },
-
-  convertToPEM: function(key, isPrivate) {
-    // curveName to OID
-    var oid = key.crv;
-    oid = curveNameToOid(oid);
-    oid = forge.asn1.oidToDer(oid);
-    // key as bytes
-    var type,
-        pub,
-        asn1;
-    if (isPrivate) {
-      type = "EC PRIVATE KEY";
-      pub = Buffer.concat([
-        Buffer.from([0x00, 0x04]),
-        key.x,
-        key.y
-      ]).toString("binary");
-      key = key.d.toString("binary");
-      asn1 = forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [
-        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.INTEGER, false, "\u0001"),
-        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OCTETSTRING, false, key),
-        forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 0, true, [
-          forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OID, false, oid.bytes())
-        ]),
-        forge.asn1.create(forge.asn1.Class.CONTEXT_SPECIFIC, 1, true, [
-          forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.BITSTRING, false, pub)
-        ])
-      ]);
-    } else {
-      type = "PUBLIC KEY";
-      key = Buffer.concat([
-        Buffer.from([0x00, 0x04]),
-        key.x,
-        key.y
-      ]).toString("binary");
-      asn1 = forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [
-        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.SEQUENCE, true, [
-          forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OID, false, forge.asn1.oidToDer(EC_OID).bytes()),
-          forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.OID, false, oid.bytes())
-        ]),
-        forge.asn1.create(forge.asn1.Class.UNIVERSAL, forge.asn1.Type.BITSTRING, false, key)
-      ]);
-    }
-    asn1 = forge.asn1.toDer(asn1).bytes();
-    var pem = forge.pem.encode({
-      type: type,
-      body: asn1
-    });
-    return pem;
   }
 };
+JWKEcCfg.convertToPEM = ecutil.convertToPEM;
 
 // Inspired by digitalbaazar/node-forge/js/rsa.js
 var validators = {

--- a/lib/jws/verify.js
+++ b/lib/jws/verify.js
@@ -66,7 +66,7 @@ var JWSVerifier = function(ks, globalOpts) {
             }
           ]
         };
-      } else if (!input || "object" === input) {
+      } else if (!input || "object" !== typeof input) {
         throw new Error("invalid input");
       }
 

--- a/test/algorithms/ecdsa-test.js
+++ b/test/algorithms/ecdsa-test.js
@@ -50,10 +50,7 @@ describe("algorithms/ecdsa", function() {
     }
   ];
 
-  vectors.forEach(function(v, idx) {
-    if (0 < idx) {
-      return;
-    }
+  vectors.forEach(function(v) {
     // NOTE: The best we can really do is consistency checks
     it("performs " + v.alg + " (" + v.desc + ") sign+verify consistency", function() {
         var key = v.key,


### PR DESCRIPTION
- fixes correct jws verify input validation `typeof` check
- make use of native node crypto for AES-KW Key-Wrapping
- make use of native node crypto for RS signing
- make use of native node crypto for RSA-OAEP and RSA1_5 encryption
- make use of native node crypto for RSA-PSS
- make use of native node crypto for RSA1_5 decryption
- makes use of native node crypto for ECDSA
- removes setImmediate/nextTick IE workaround

I kindly ask for a review, especially for aa5a48d which as noted is inspired by another published implementation

with this in place the only use of `node-forge` in node lts/carbon is for converting keys between formats and `RSA-OAEP-256`

closes #203
fixes #210
closes #202

Note: can we remove non lts versions of node from travis? `RSASSA-PSS` support was added in `^6.12.0 || ^8.0.0`, never landed in 7