### PR TITLE
bug: fix failures on Edge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6102,6 +6102,12 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
+    "is-safari": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-safari/-/is-safari-1.0.0.tgz",
+      "integrity": "sha1-tGENXqdar2x2Ef2h0P095H3nK5s=",
+      "dev": true
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -7890,9 +7896,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
-      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-libs-browser": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash.pick": "^4.2.0",
     "lodash.uniq": "^4.2.1",
     "long": "^4.0.0",
-    "node-forge": "^0.7.1",
+    "node-forge": "^0.7.6",
     "uuid": "^3.0.1"
   },
   "devDependencies": {
@@ -57,6 +57,7 @@
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^3.0.0",
     "gulp-util": "^3.0.7",
+    "is-safari": "^1.0.0",
     "istanbul": "^0.4.0",
     "jose-cookbook": "git+https://github.com/ietf-jose/cookbook.git",
     "json-loader": "^0.5.4",

--- a/test/algorithms/ecdsa-test.js
+++ b/test/algorithms/ecdsa-test.js
@@ -6,9 +6,18 @@
 
 var chai = require("chai");
 var assert = chai.assert;
+var isSafari = require("is-safari");
 
 var algorithms = require("../../lib/algorithms/"),
     util = require("../../lib/util");
+
+function shouldSkip(vector) {
+  if ("ES512" !== vector.alg) {
+    return false;
+  }
+
+  return isSafari;
+}
 
 describe("algorithms/ecdsa", function() {
   var vectors = [
@@ -51,6 +60,10 @@ describe("algorithms/ecdsa", function() {
   ];
 
   vectors.forEach(function(v) {
+    if (shouldSkip(v)) {
+      return;
+    }
+
     // NOTE: The best we can really do is consistency checks
     it("performs " + v.alg + " (" + v.desc + ") sign+verify consistency", function() {
         var key = v.key,


### PR DESCRIPTION
Edge fails with "invalid calling object" because of some incorrect detection logic within `node-forge`.

Safari fails because it does not support NIST curve `P-521`.  While this PR addresses both, the most impactful is Edge.