### PR TITLE
Fix bug when only supplied 1 jwk

### DIFF
--- a/lib/jws/verify.js
+++ b/lib/jws/verify.js
@@ -242,9 +242,9 @@ var JWSVerifier = function(ks, globalOpts) {
                 return jws;
               });
             });
-            p.then(resolve, processSig);
+            p.then(resolve, sigList.length >= 1 ? processSig : () => {});
           };
-          processSig();
+          if (sigList.length >= 1) processSig();
         });
       });
       return promise;


### PR DESCRIPTION
This fixes a error when there is only 1 jwk in the list.

If just supplying 1 jwk is fundamentally wrong please tell me, but I think Auth0 only supplies 1 jwk according to this: https://auth0.com/docs/jwks.