### PR TITLE
Do not replace forge.util.ByteBuffer (#266)

### DIFF
--- a/lib/util/databuffer.js
+++ b/lib/util/databuffer.js
@@ -471,4 +471,4 @@ DataBuffer.asBuffer = function(orig) {
          new DataBuffer();
 };
 
-module.exports = forge.util.ByteBuffer = DataBuffer;
+module.exports = DataBuffer;


### PR DESCRIPTION
Fix: #266 
Do not replace forge.util.ByteBuffer with util.databuffer.DataBuffer
