### PR TITLE
Add better react and react-native compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,12 +11,12 @@ if (typeof Promise === "undefined") {
 
 if (typeof Buffer === "undefined") {
   const g = global || window;
-  g.Buffer = require("buffer/").Buffer;
+  g.Buffer = require("buffer").Buffer;
 }
 
 if (typeof process === "undefined") {
   const g = global || window;
-  g.process = require("process/");
+  g.process = require("process");
 }
 
 if (!process.version) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,13 +10,11 @@ if (typeof Promise === "undefined") {
 }
 
 if (typeof Buffer === "undefined") {
-  const g = global || window;
-  g.Buffer = require("buffer").Buffer;
+  (global || window).Buffer = require("buffer").Buffer;
 }
 
 if (typeof process === "undefined") {
-  const g = global || window;
-  g.process = require("process");
+  (global || window).process = require("process");
 }
 
 if (!process.version) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ if (typeof process === "undefined") {
 }
 
 if (!process.version) {
-  process.version = '';
+  process.version = "";
 }
 
 var JWS = require("./jws");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-jose",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "A JavaScript implementation of the JSON Object Signing and Encryption (JOSE) for current web browsers and node.js-based servers",
   "keywords": [
     "crypto",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "crypto": false,
     "zlib": "browserify-zlib"
   },
+  "react-native": {
+    "crypto": false,
+    "zlib": "react-zlib-js"
+  },
   "dependencies": {
     "base64url": "^3.0.1",
     "browserify-zlib": "^0.2.0",
@@ -39,6 +43,7 @@
     "long": "^4.0.0",
     "node-forge": "^0.8.5",
     "process": "^0.11.10",
+    "react-zlib-js": "^1.0.4",
     "uuid": "^3.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   },
   "browser": {
     "crypto": false,
-    "zlib": "zlib-browserify"
+    "zlib": "browserify-zlib"
   },
   "dependencies": {
     "base64url": "^3.0.1",
+    "browserify-zlib": "^0.2.0",
     "buffer": "^5.5.0",
     "es6-promise": "^4.2.8",
     "lodash": "^4.17.15",
     "long": "^4.0.0",
     "node-forge": "^0.8.5",
     "process": "^0.11.10",
-    "uuid": "^3.3.3",
-    "zlib-browserify": "^0.0.3"
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "bowser": "^1.9.3",


### PR DESCRIPTION
Hi maintainers,

I'm trying to integrate this library into my react and react-native projects.
I believe, the following small changes will help:
- add `buffer` dependency, and polyfill global `Buffer`
- add `process` dependency, and minimally polyfill global `process`
- add `browserify-zlib` dependency for browser type environment
- add `react-zlib-js` dependency for react-native type environment