### PR TITLE
fix algorithms fallback functions

### DIFF
--- a/lib/algorithms/aes-cbc-hmac-sha2.js
+++ b/lib/algorithms/aes-cbc-hmac-sha2.js
@@ -41,7 +41,7 @@ function commonCbcEncryptFN(size) {
         return Promise.reject(new Error("encryption failed"));
       }
 
-      var cdata = cipher.output.native();
+      var cdata = Buffer.from(cipher.output.bytes(), "binary");
       return cdata;
     });
 
@@ -130,7 +130,7 @@ function commonCbcDecryptFN(size) {
         return Promise.reject(new Error("encryption failed"));
       }
 
-      var pdata = cipher.output.native();
+      var pdata = Buffer.from(cipher.output.bytes(), "binary");
       return pdata;
     });
 

--- a/lib/algorithms/aes-kw.js
+++ b/lib/algorithms/aes-kw.js
@@ -78,7 +78,7 @@ function kwEncryptFN(size) {
         cipher.start();
         cipher.update(new DataBuffer(B));
         cipher.finish();
-        B = cipher.output.native();
+        B = Buffer.from(cipher.output.bytes(), "binary");
 
         A = xor(B.slice(0, 8),
                 longToBigEndian(count));
@@ -194,7 +194,7 @@ function kwDecryptFN(size) {
         cipher.start();
         cipher.update(new DataBuffer(B));
         cipher.finish();
-        B = cipher.output.native();
+        B = Buffer.from(cipher.output.bytes(), "binary");
 
         A = B.slice(0, 8);
         R[idx] = B.slice(8, 16);

--- a/lib/algorithms/hmac.js
+++ b/lib/algorithms/hmac.js
@@ -31,8 +31,8 @@ function hmacSignFN(name) {
     promise = promise.then(function() {
       var sig = forge.hmac.create();
       sig.start(md, key.toString("binary"));
-      sig.update(pdata);
-      sig = sig.digest().native();
+      sig.update(pdata.toString("binary"));
+      sig = Buffer.from(sig.digest().bytes(), "binary");
 
       return {
         data: pdata,
@@ -112,8 +112,8 @@ function hmacVerifyFN(name) {
 
     var vrfy = forge.hmac.create();
     vrfy.start(md, new DataBuffer(key));
-    vrfy.update(pdata);
-    vrfy = vrfy.digest().native();
+    vrfy.update(pdata.toString("binary"));
+    vrfy = Buffer.from(vrfy.digest().bytes(), "binary");
 
     if (compare(props.length, mac, vrfy)) {
       return Promise.resolve({

--- a/lib/algorithms/sha.js
+++ b/lib/algorithms/sha.js
@@ -18,8 +18,8 @@ function hashDigestFN(hash) {
   // ### Fallback Implementation -- uses forge
   var fallback = function(pdata /* props */) {
     var digest = forge.md[md].create();
-    digest.update(pdata);
-    digest = digest.digest().native();
+    digest.update(pdata.toString("binary"));
+    digest = Buffer.from(digest.digest().bytes(), "binary");
 
     return Promise.resolve(digest);
   };


### PR DESCRIPTION
When I was working with this library, I noticed that I was getting invalid results.

When the library is not able to access `crypto` and `WebCrypto API` modules, it defaults to using some fallback functions, which rely mostly on `node-forge`. I have found that some of the logic are throwing errors.

We can simulate this condition by the following:
1. Patch the `helpers.setupFallback()` method to always use fallback algorithms
file: `lib/algorithms/helpers.js`
lines: [92 - 94](https://github.com/cisco/node-jose/blob/master/lib/algorithms/helpers.js#L94)
```javascript
// other codes
exports.setupFallback = function(nodejs, webcrypto, fallback) {
  var impl;
  nodejs = false; // add this
  webcrypto = false; // add this
  if (nodejs && exports.nodeCrypto) {
// other codes
```
2. Run the test suites
```bash
yarn test
```

Most unit test would fail. It seems like some of the algorithms are not calling into `node-forge` correctly. Perhaps there was some API change?

I believe this PR will address this.

**HOW TO TEST**
Make the code change above temporary, to force using fallback functions. Then run the test suite.