### PR TITLE
Replace browserify-zlib with webpack v5 compatible pako

### DIFF
--- a/lib/jwe/decrypt.js
+++ b/lib/jwe/decrypt.js
@@ -9,7 +9,7 @@ var base64url = require("../util/base64url"),
     AlgConfig = require("../util/algconfig"),
     JWK = require("../jwk"),
     merge = require("../util/merge"),
-    zlib = require("zlib");
+    pako = require("pako");
 
 var DEFAULT_OPTIONS = {
   algorithms: "*"
@@ -285,17 +285,17 @@ function JWEDecrypter(ks, globalOpts) {
       promise = promise.then(function(jwe) {
         if ("DEF" === jwe.header.zip) {
           return new Promise(function(resolve, reject) {
-            zlib.inflateRaw(Buffer.from(jwe.plaintext), function(err, data) {
-              if (err) {
-                reject(err);
-              }
-              else {
-                jwe.payload = jwe.plaintext = data;
-                resolve(jwe);
-              }
-            });
+            try {
+              var data = pako.inflateRaw(Buffer.from(jwe.plaintext))
+
+              jwe.payload = jwe.plaintext = Buffer.from(data);
+              resolve(jwe);
+            } catch (err) {
+              reject(err);
+            }
           });
         }
+
         return jwe;
       });
 

--- a/lib/jwe/encrypt.js
+++ b/lib/jwe/encrypt.js
@@ -10,7 +10,7 @@ var lodash = require("lodash"),
     generateCEK = require("./helpers").generateCEK,
     JWK = require("../jwk"),
     slice = require("./helpers").slice,
-    zlib = require("zlib"),
+    pako = require("pako"),
     CONSTANTS = require("../algorithms/constants");
 
 var assign = lodash.assign;
@@ -369,15 +369,14 @@ function JWEEncrypter(cfg, fields, recipients) {
           return jwe;
         } else if (props.zip === "DEF") {
           return new Promise(function(resolve, reject) {
-            zlib.deflateRaw(Buffer.from(pdata, "binary"), function(err, data) {
-              if (err) {
-                reject(err);
-              }
-              else {
-                jwe.plaintext = data;
-                resolve(jwe);
-              }
-            });
+            try {
+              var data = pako.deflateRaw(Buffer.from(pdata, "binary"));
+
+              jwe.plaintext = data;
+              resolve(jwe);
+            } catch (error) {
+              reject(error);
+            }
           });
         }
         return Promise.reject(new Error("unsupported 'zip' mode"));

--- a/package.json
+++ b/package.json
@@ -28,22 +28,21 @@
   },
   "browser": {
     "crypto": false,
-    "zlib": "browserify-zlib"
+    "zlib": "pako"
   },
   "react-native": {
     "crypto": false,
-    "zlib": "react-zlib-js"
+    "zlib": "pako"
   },
   "dependencies": {
     "base64url": "^3.0.1",
-    "browserify-zlib": "^0.2.0",
     "buffer": "^5.5.0",
     "es6-promise": "^4.2.8",
     "lodash": "^4.17.15",
     "long": "^4.0.0",
     "node-forge": "^0.8.5",
+    "pako": "^1.0.11",
     "process": "^0.11.10",
-    "react-zlib-js": "^1.0.4",
     "uuid": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi team,

I'm a fellow Cisco employee working on the Webex JS SDK.
We're working on getting some of our projects working with the upcoming webpack v5, which loses node builtins.
This libraries' use of zlib is raising an error and while it would be easier to just alias it in the webpack config, we'd like to move off webpack to something else.
I've been deep-diving into our SDK to see what else needs to be "polyfilled"/"isomorphed" so we dont need to use node only version of packages

We also need to update `node-scr` and `node-kms` to use the latest version of `node-jose`