### PR TITLE
Cherry-pick lodash modules to make webpack bundle files smaller

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,6 @@ var ARGV = require("yargs").
     argv;
 
 var webpack = require("webpack-stream"),
-    lodash = require("lodash"),
     gulp = require("gulp"),
     gutil = require("gulp-util"),
     karma = require("karma"),
@@ -34,8 +33,8 @@ var webpack = require("webpack-stream"),
     istanbul = require("gulp-istanbul"),
     del = require("del");
 
-var clone = lodash.clone;
-var merge = lodash.merge;
+var clone = require("lodash/clone");
+var merge = require("lodash/merge");
 // ### 'CONSTANTS' ###
 var SOURCES = ["./lib/**/*.js", "!(./lib/old/**/*.js)"],
     TESTS = "./test/**/*-test.js";

--- a/lib/algorithms/ec-util.js
+++ b/lib/algorithms/ec-util.js
@@ -5,7 +5,7 @@
  */
 "use strict";
 
-var clone = require("lodash").clone,
+var clone = require("lodash/clone"),
     ecc = require("../deps/ecc"),
     forge = require("../deps/forge.js"),
     util = require("../util");

--- a/lib/algorithms/ecdh.js
+++ b/lib/algorithms/ecdh.js
@@ -5,8 +5,7 @@
  */
 "use strict";
 
-var lodash = require("lodash"),
-    merge = require("../util/merge"),
+var merge = require("../util/merge"),
     util = require("../util"),
     ecUtil = require("./ec-util.js"),
     hkdf = require("./hkdf.js"),
@@ -15,9 +14,9 @@ var lodash = require("lodash"),
     helpers = require("./helpers.js"),
     CONSTANTS = require("./constants.js");
 
-var clone = lodash.clone;
-var omit = lodash.omit;
-var pick = lodash.pick;
+var clone = require("lodash/clone");
+var omit = require("lodash/omit");
+var pick = require("lodash/pick");
 
 function idealHash(curve) {
   switch (curve) {

--- a/lib/algorithms/rsa-util.js
+++ b/lib/algorithms/rsa-util.js
@@ -5,7 +5,7 @@
  */
 "use strict";
 
-var clone = require("lodash").clone,
+var clone = require("lodash/clone"),
     forge = require("../deps/forge.js"),
     util = require("../util");
 

--- a/lib/deps/ciphermodes/gcm/helpers.js
+++ b/lib/deps/ciphermodes/gcm/helpers.js
@@ -6,7 +6,7 @@
 "use strict";
 
 var Long = require("long"),
-    fill = require("lodash").fill,
+    fill = require("lodash/fill"),
     pack = require("../pack.js");
 
 var E1 = 0xe1000000,

--- a/lib/jwe/encrypt.js
+++ b/lib/jwe/encrypt.js
@@ -5,17 +5,15 @@
  */
 "use strict";
 
-var lodash = require("lodash"),
-    util = require("../util"),
+var util = require("../util"),
     generateCEK = require("./helpers").generateCEK,
     JWK = require("../jwk"),
     slice = require("./helpers").slice,
     pako = require("pako"),
     CONSTANTS = require("../algorithms/constants");
 
-var assign = lodash.assign;
-var clone = lodash.clone;
-
+var assign = require("lodash/assign");
+var clone = require("lodash/clone");
 var DEFAULTS = require("./defaults");
 
 /**

--- a/lib/jwk/basekey.js
+++ b/lib/jwk/basekey.js
@@ -5,17 +5,16 @@
  */
 "use strict";
 
-var lodash = require("lodash"),
-    merge = require("../util/merge"),
+var merge = require("../util/merge"),
     uuid = require("uuid");
 
-var assign = lodash.assign;
-var clone = lodash.clone;
-var flatten = lodash.flatten;
-var intersection = lodash.intersection;
-var omit = lodash.omit;
-var pick = lodash.pick;
-var uniq = lodash.uniq;
+var assign = require("lodash/assign");
+var clone = require("lodash/clone");
+var flatten = require("lodash/flatten");
+var intersection = require("lodash/intersection");
+var omit = require("lodash/omit");
+var pick = require("lodash/pick");
+var uniq = require("lodash/uniq");
 
 var ALGORITHMS = require("../algorithms"),
     CONSTANTS = require("./constants.js"),

--- a/lib/jwk/helpers.js
+++ b/lib/jwk/helpers.js
@@ -5,7 +5,7 @@
  */
 "use strict";
 
-var clone = require("lodash").clone,
+var clone = require("lodash/clone"),
     util = require("../util"),
     forge = require("../deps/forge");
 

--- a/lib/jwk/keystore.js
+++ b/lib/jwk/keystore.js
@@ -5,7 +5,7 @@
  */
 "use strict";
 
-var clone = require("lodash").clone,
+var clone = require("lodash/clone"),
     merge = require("../util/merge"),
     forge = require("../deps/forge"),
     util = require("../util");

--- a/lib/jws/sign.js
+++ b/lib/jws/sign.js
@@ -5,14 +5,13 @@
  */
 "use strict";
 
-var lodash = require("lodash"),
-    merge = require("../util/merge"),
+var merge = require("../util/merge"),
     util = require("../util"),
     JWK = require("../jwk"),
     slice = require("./helpers").slice;
 
-var clone = lodash.clone;
-var uniq = lodash.uniq;
+var clone = require("lodash/clone");
+var uniq = require("lodash/uniq");
 
 var DEFAULTS = require("./defaults");
 

--- a/lib/jws/verify.js
+++ b/lib/jws/verify.js
@@ -5,7 +5,7 @@
  */
 "use strict";
 
-var clone = require("lodash").clone,
+var clone = require("lodash/clone"),
     merge = require("../util/merge"),
     base64url = require("../util/base64url"),
     AlgConfig = require("../util/algconfig"),

--- a/lib/util/merge.js
+++ b/lib/util/merge.js
@@ -5,10 +5,8 @@
  */
 "use strict";
 
-var lodash = require("lodash");
-
-var partialRight = lodash.partialRight;
-var merge = lodash.merge;
+var partialRight = require("lodash/partialRight");
+var merge = require("lodash/merge");
 
 var typedArrayCtors = (function() {
   var ctors = [];

--- a/test/algorithms/ecdh-test.js
+++ b/test/algorithms/ecdh-test.js
@@ -4,7 +4,7 @@
  */
 "use strict";
 
-var omit = require("lodash").omit,
+var omit = require("lodash/omit"),
     chai = require("chai"),
     bowser = require("bowser");
 var assert = chai.assert;

--- a/test/jwe/invalidecdh-test.js
+++ b/test/jwe/invalidecdh-test.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-var forEach = require("lodash").forEach;
+var forEach = require("lodash/forEach")
 var chai = require("chai");
 
 var JWE = require("../../lib/jwe"),

--- a/test/jwe/jwe-test.js
+++ b/test/jwe/jwe-test.js
@@ -4,8 +4,8 @@
  */
 "use strict";
 
-var cloneDeep = require("lodash").cloneDeep;
-var forEach = require("lodash").forEach;
+var cloneDeep = require("lodash/cloneDeep");
+var forEach = require("lodash/forEach")
 var chai = require("chai");
 
 var JWE = require("../../lib/jwe"),

--- a/test/jwe/roundtrip-test.js
+++ b/test/jwe/roundtrip-test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var forEach = require("lodash").forEach;
+var forEach = require("lodash/forEach")
 var chai = require("chai");
 
 var JWE = require("../../lib/jwe"),

--- a/test/jwk/eckey-test.js
+++ b/test/jwk/eckey-test.js
@@ -5,11 +5,11 @@
 "use strict";
 
 var chai = require("chai"),
-    bind = require("lodash").bind,
-    clone = require("lodash").clone,
+    bind = require("lodash/bind"),
+    clone = require("lodash/clone"),
     merge = require("../../lib/util/merge"),
-    omit = require("lodash").omit,
-    pick = require("lodash").pick;
+    omit = require("lodash/omit"),
+    pick = require("lodash/pick");
 var assert = chai.assert;
 
 var JWK = {

--- a/test/jwk/octkey-test.js
+++ b/test/jwk/octkey-test.js
@@ -6,7 +6,7 @@
 
 var chai = require("chai"),
     forge = require("node-forge"),
-    clone = require("lodash").clone,
+    clone = require("lodash/clone"),
     merge = require("../../lib/util/merge");
 var assert = chai.assert;
 

--- a/test/jwk/rsakey-test.js
+++ b/test/jwk/rsakey-test.js
@@ -5,11 +5,11 @@
 "use strict";
 
 var chai = require("chai");
-var bind = require("lodash").bind;
-var clone = require("lodash").clone;
+var bind = require("lodash/bind");
+var clone = require("lodash/clone");
 var merge = require("../../lib/util/merge");
-var omit = require("lodash").omit;
-var pick = require("lodash").pick;
+var omit = require("lodash/omit");
+var pick = require("lodash/pick");
 var assert = chai.assert;
 
 var JWK = {

--- a/test/jws/jws-test.js
+++ b/test/jws/jws-test.js
@@ -4,8 +4,8 @@
  */
 "use strict";
 
-var cloneDeep = require("lodash").cloneDeep;
-var forEach = require("lodash").forEach;
+var cloneDeep = require("lodash/cloneDeep");
+var forEach = require("lodash/forEach")
 var chai = require("chai");
 var bowser = require("bowser");
 

--- a/test/parse/compact-test.js
+++ b/test/parse/compact-test.js
@@ -7,7 +7,7 @@
 var chai = require("chai");
 var assert = chai.assert;
 
-var cloneDeep = require("lodash").cloneDeep;
+var cloneDeep = require("lodash/cloneDeep");
 var parseCompact = require("../../lib/parse/compact");
 var jose = {
   JWK: require("../../lib/jwk")

--- a/test/parse/index-test.js
+++ b/test/parse/index-test.js
@@ -7,7 +7,7 @@
 var chai = require("chai");
 var assert = chai.assert;
 
-var cloneDeep = require("lodash").cloneDeep;
+var cloneDeep = require("lodash/cloneDeep");
 var merge = require("../../lib/util/merge");
 
 var jose = {

--- a/test/parse/json-test.js
+++ b/test/parse/json-test.js
@@ -7,7 +7,7 @@
 var chai = require("chai");
 var assert = chai.assert;
 
-var cloneDeep = require("lodash").cloneDeep;
+var cloneDeep = require("lodash/cloneDeep");
 var merge = require("../../lib/util/merge");
 var parseJSON = require("../../lib/parse/json");
 


### PR DESCRIPTION
node-jose heavily depends on lodash. When using node-jose in a webpack base project, all lodash modules will be included in the bundle files, resulting in a big bundled js.

![Screenshot from 2020-06-05 20-58-02](https://user-images.githubusercontent.com/6280428/83879199-db428680-a76f-11ea-9a85-13f825361c89.png)

[babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) provides a way to decrease the bundled file size. But it doesn't work with node-jose because node-jose doesn't use ES2015 import syntax.

This PR manually cherry-pick the needed lodash modules and make the bundle smaller.

Here's the comparison. The stat size is decreased from 527.84kb to 167.13kb. 

![Screenshot from 2020-06-05 20-54-47](https://user-images.githubusercontent.com/6280428/83879536-5dcb4600-a770-11ea-8e46-bfe80c2c72b9.png)


