### PR TITLE
minor fixes for react-native and fallback methods

### DIFF
--- a/lib/jwe/encrypt.js
+++ b/lib/jwe/encrypt.js
@@ -370,7 +370,7 @@ function JWEEncrypter(cfg, fields, recipients) {
             try {
               var data = pako.deflateRaw(Buffer.from(pdata, "binary"));
 
-              jwe.plaintext = data;
+              jwe.plaintext = Buffer.from(data);
               resolve(jwe);
             } catch (error) {
               reject(error);

--- a/package.json
+++ b/package.json
@@ -27,12 +27,10 @@
     "test": "gulp test:nodejs"
   },
   "browser": {
-    "crypto": false,
-    "zlib": "pako"
+    "crypto": false
   },
   "react-native": {
-    "crypto": false,
-    "zlib": "pako"
+    "crypto": false
   },
   "dependencies": {
     "base64url": "^3.0.1",


### PR DESCRIPTION
After the recent release of `2.0.0`, and merge of this PR #287 , I noticed that some fallback functions were failing unit tests.

When the library is not able to access `crypto` and `WebCrypto API` modules, it defaults to using some fallback functions, which rely mostly on `node-forge` and now `pako`. I have found that some of the logic are throwing errors.

We can simulate this condition by the following:
1. Patch the `helpers.setupFallback()` method to always use fallback algorithms
file: `lib/algorithms/helpers.js`
lines: [92 - 94](https://github.com/cisco/node-jose/blob/master/lib/algorithms/helpers.js#L94)
```javascript
// other codes
exports.setupFallback = function(nodejs, webcrypto, fallback) {
  var impl;
  nodejs = false; // add this
  webcrypto = false; // add this
  if (nodejs && exports.nodeCrypto) {
// other codes
```
2. Run the test suites
```bash
npm test
```

Some `encrypt` unit tests would fail:
```
  jwe
    Compressed Content
      1) encrypts to a compact JWE -failed
      2) encrypts to a general JSON JWE -failed
      3) encrypts to a flattened JSON JWE -failed
      ✓ decrypts from a compact JWE
      ✓ decrypts from a general JSON JWE
      ✓ decrypts from a flattened JSON JWE

TypeError: inV.copy is not a function
      at Gcm.update (lib/deps/ciphermodes/gcm/index.js:126:9)
      at doChunk (lib/algorithms/aes-gcm.js:75:24)
      at /Users/ragib/Projects/ragibkl/node-jose/lib/algorithms/aes-gcm.js:100:9
      at new Promise (<anonymous>)
      at fallback (lib/algorithms/aes-gcm.js:68:19)
      at Object.exports.encrypt (lib/algorithms/index.js:100:10)
      at JWKBaseKeyObject.value (lib/jwk/basekey.js:564:25)
      at /Users/ragib/Projects/ragibkl/node-jose/lib/jwe/encrypt.js:414:26
```

Reason: Previously when node `zlib.deflateRaw` returns a `Buffer` object, `pako.deflateRaw` returns a `UInt8Array`.

I believe this PR will address this.

Additionally, since we are no longer importing `zlib` from anywhere in code, we should remove the import rewrites that webpack uses for them.

**HOW TO TEST**
Make the code change above temporary, to force using fallback functions. Then run the test suite.