### PR TITLE
fix accidental merge of DEFAULT_OPTIONS in JWEDecrypter

### DIFF
--- a/lib/jwe/decrypt.js
+++ b/lib/jwe/decrypt.js
@@ -36,7 +36,7 @@ function JWEDecrypter(ks, globalOpts) {
     throw new TypeError("Keystore must be provided");
   }
 
-  globalOpts = merge(DEFAULT_OPTIONS, globalOpts);
+  globalOpts = merge({}, DEFAULT_OPTIONS, globalOpts);
 
   /**
    * Decrypts the given input.

--- a/test/jwe/default-alg.js
+++ b/test/jwe/default-alg.js
@@ -1,0 +1,73 @@
+"use strict";
+
+var chai = require("chai");
+
+var JWE = require("../../lib/jwe"),
+  JWK = require("../../lib/jwk");
+
+var assert = chai.assert;
+
+describe("jwe/allowedalgs", function() {
+  var a256kw = {
+    key: {
+      "kty": "oct",
+      "kid": "lkSOb9wLb8VTKr0Z1TMqQoa_oSoNNn8uukn6taSuwS0",
+      "k": "o9oXnnQleK4oDDN1AngQ610cn39o6Y8KPirzITJRfWw",
+      "alg": "A256KW"
+    },
+    fields: {
+      enc: "A256GCM"
+    },
+    plaintext: "this is not good content"
+  };
+  var a256gcm = {
+    key: {
+      "kty": "oct",
+      "kid": "V5O0olRc1BSdaubnd_REP2B0xBjo8gBmNcLlv_F8hk0",
+      "k": "wB_gTgRKTtYSk-ul_W-96WU92evFr01tPN6WE8A8BEU",
+      "alg": "A256GCM"
+    },
+    plaintext: "this is very good content"
+  };
+
+  function decryptAllowed(vector, opts) {
+    var p;
+    p = JWE.createDecrypt(vector.key, opts).
+      decrypt(vector.encrypted);
+    p = p.then(function (result) {
+      assert.strictEqual(result.payload.toString("utf8"), vector.plaintext);
+    });
+    return p;
+  }
+
+  before(function() {
+    var pending = [a256gcm, a256kw].map(function(vector) {
+      var p = JWK.asKey(vector.key);
+      p = p.then(function(result) {
+        vector.key = result;
+        return result;
+      });
+      p = p.then(function(key) {
+        return JWE.createEncrypt({ format: "compact", fields: vector.fields }, key).final(vector.plaintext, "utf8");
+      });
+      p = p.then(function(result) {
+        vector.encrypted = result;
+        return result;
+      });
+      return p;
+    });
+    return Promise.all(pending);
+  });
+
+  it("Default algorithm is preserved", function() {
+    var opts = {
+      algorithms: ["dir", "A256GCM"]
+    };
+
+    var pending = [
+      decryptAllowed(a256gcm, opts),
+      decryptAllowed(a256kw, {})
+    ];
+    return Promise.all(pending);
+  });
+});


### PR DESCRIPTION
Addresses #312.

An explicit options argument overwrites the internal defaults when provided to `new JWEDecrypter(ks, globalOpts)` or `JWE.createDecrypt(ks, globalOpts)`.
This causes an error when decrypting tokens after an explicit algorithm option was provided to a previous decrypt attempt.
The added test case demonstrates that decrypting an `a256gcm` token works fine at first, but the following `a256kw` does not, even though the assumed default is `algorithms: "*"` which should let the token through the decryption.

