### PR TITLE
feat: Update uuid dependency

### DIFF
--- a/lib/jwk/basekey.js
+++ b/lib/jwk/basekey.js
@@ -5,8 +5,8 @@
  */
 "use strict";
 
-var merge = require("../util/merge"),
-    uuid = require("uuid");
+var merge = require("../util/merge");
+var uuid = require("uuid");
 
 var assign = require("lodash/assign");
 var clone = require("lodash/clone");
@@ -77,7 +77,7 @@ var JWKBaseKeyObject = function(kty, ks, props, cfg) {
 
   // force certain values
   props.kty = kty;
-  props.kid = props.kid || kid || uuid();
+  props.kid = props.kid || kid || uuid.v4();
 
   // setup base info
   var included = Object.keys(HELPERS.COMMON_PROPS).map(function(p) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9983,9 +9983,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8flags": {
       "version": "3.2.0",
@@ -10325,6 +10325,14 @@
             "tough-cookie": "~2.4.3",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+              "dev": true
+            }
           }
         },
         "tough-cookie": {
@@ -10481,6 +10489,12 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-forge": "^0.10.0",
     "pako": "^1.0.11",
     "process": "^0.11.10",
-    "uuid": "^3.3.3"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "bowser": "^1.9.3",


### PR DESCRIPTION
Fairly straightforward, this patch updates the uuid dep to its latest version. This is mostly to stop node-jose printing a pesky deprecation warning :)