### PR TITLE
Add brainpoolP256r1 curve support

### DIFF
--- a/lib/algorithms/ec-util.js
+++ b/lib/algorithms/ec-util.js
@@ -12,6 +12,7 @@ var clone = require("lodash/clone"),
 
 var EC_KEYSIZES = {
   "P-256": 256,
+  "BP-256": 256,
   "P-384": 384,
   "P-521": 521
 };
@@ -86,6 +87,8 @@ function curveNameToOid(crv) {
       return "1.3.132.0.34";
     case "P-521":
       return "1.3.132.0.35";
+    case "BP-256":
+      return "1.3.36.3.3.2.8.1.1.7";
     default:
       return null;
   }

--- a/lib/algorithms/ecdh.js
+++ b/lib/algorithms/ecdh.js
@@ -21,6 +21,7 @@ var pick = require("lodash/pick");
 function idealHash(curve) {
   switch (curve) {
     case "P-256":
+    case "BP-256":
       return "SHA-256";
     case "P-384":
       return "SHA-384";
@@ -152,6 +153,9 @@ function ecdhDeriveFn() {
         break;
       case "P-521":
         curve = "secp521r1";
+        break;
+      case "BP-256":
+        curve = "brainpoolP256r1";
         break;
       default:
         return Promise.reject(new Error("invalid curve: " + curve));

--- a/lib/algorithms/ecdsa.js
+++ b/lib/algorithms/ecdsa.js
@@ -9,25 +9,26 @@ var ecUtil = require("./ec-util.js"),
     helpers = require("./helpers.js"),
     sha = require("./sha.js");
 
+// TODO: Handle gracefully
 function idealCurve(hash) {
   switch (hash) {
     case "SHA-256":
-      return "P-256";
+      return ["P-256", "BP-256"];
     case "SHA-384":
-      return "P-384";
+      return ["P-384"];
     case "SHA-512":
-      return "P-521";
+      return ["P-521"];
     default:
       throw new Error("unsupported hash: " + hash);
   }
 }
 
 function ecdsaSignFN(hash) {
-  var curve = idealCurve(hash);
+  var curves = idealCurve(hash);
 
   // ### Fallback implementation -- uses forge
   var fallback = function(key, pdata /*, props */) {
-    if (curve !== key.crv) {
+    if (!curves.includes(key.crv)) {
       return Promise.reject(new Error("invalid curve"));
     }
     var pk = ecUtil.convertToForge(key, false);
@@ -49,7 +50,7 @@ function ecdsaSignFN(hash) {
 
   // ### WebCrypto API implementation
   var webcrypto = function(key, pdata /*, props */) {
-    if (curve !== key.crv) {
+    if (!curves.includes(key.crv)) {
       return Promise.reject(new Error("invalid curve"));
     }
     var pk = ecUtil.convertToJWK(key, false);
@@ -84,7 +85,7 @@ function ecdsaSignFN(hash) {
   var nodeHash = hash.toLowerCase().replace("-", "");
   if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(nodeHash) > -1) {
     nodejs = function(key, pdata) {
-      if (curve !== key.crv) {
+      if (!curves.includes(key.crv)) {
         return Promise.reject(new Error("invalid curve"));
       }
 
@@ -127,11 +128,11 @@ function ecdsaSignFN(hash) {
 }
 
 function ecdsaVerifyFN(hash) {
-  var curve = idealCurve(hash);
+  var curves = idealCurve(hash);
 
   // ### Fallback implementation -- uses forge
   var fallback = function(key, pdata, mac /*, props */) {
-    if (curve !== key.crv) {
+    if (!curves.includes(key.crv)) {
       return Promise.reject(new Error("invalid curve"));
     }
     var pk = ecUtil.convertToForge(key, true);
@@ -160,7 +161,7 @@ function ecdsaVerifyFN(hash) {
 
   // ### WebCrypto API implementation
   var webcrypto = function(key, pdata, mac /* , props */) {
-    if (curve !== key.crv) {
+    if (!curves.includes(key.crv)) {
       return Promise.reject(new Error("invalid curve"));
     }
     var pk = ecUtil.convertToJWK(key, true);
@@ -198,7 +199,7 @@ function ecdsaVerifyFN(hash) {
   var nodeHash = hash.toLowerCase().replace("-", "");
   if (helpers.nodeCrypto && helpers.nodeCrypto.getHashes().indexOf(nodeHash) > -1) {
     nodejs = function(key, pdata, mac /* , props */) {
-      if (curve !== key.crv) {
+      if (!curves.includes(key.crv)) {
         return Promise.reject(new Error("invalid curve"));
       }
 
@@ -247,11 +248,13 @@ var ecdsa = {};
 [
   "ES256",
   "ES384",
-  "ES512"
+  "ES512",
+  "BP256R1"
 ].forEach(function(name) {
-  var hash = name.replace(/ES(\d+)/g, function(m, size) {
+  var hash = name.replace(/(?:ES|BP)(\d+)\S*/g, function(m, size) {
     return "SHA-" + size;
   });
+
   ecdsa[name] = {
     sign: ecdsaSignFN(hash),
     verify: ecdsaVerifyFN(hash)

--- a/lib/algorithms/helpers.js
+++ b/lib/algorithms/helpers.js
@@ -103,8 +103,10 @@ exports.setupFallback = function(nodejs, webcrypto, fallback) {
       }
 
       try {
-        promise = Promise.resolve(nodejs.apply(null, args));
-        promise = promise.catch(check);
+        // nodejs.apply is a synchronous function that can throw, but returns a promise that can also reject
+        // Hence, we need to both wrap the call to it in a try/catch, and call Promise.catch to properly fallback
+        // to the next implementation
+        promise = Promise.resolve(nodejs.apply(null, args)).catch(check);
       } catch(err) {
         promise = check(err);
       }

--- a/lib/algorithms/helpers.js
+++ b/lib/algorithms/helpers.js
@@ -97,13 +97,9 @@ exports.setupFallback = function(nodejs, webcrypto, fallback) {
       var args = arguments,
           promise;
 
-      function check(err) {
-        if (0 === err.message.indexOf("unsupported algorithm:") || err.message.includes("Failed to create key using named curve")) {
-          impl = fallback;
-          return impl.apply(null, args);
-        }
-
-        return Promise.reject(err);
+      function check(_err) {
+        impl = fallback;
+        return impl.apply(null, args);
       }
 
       try {

--- a/lib/algorithms/helpers.js
+++ b/lib/algorithms/helpers.js
@@ -98,7 +98,7 @@ exports.setupFallback = function(nodejs, webcrypto, fallback) {
           promise;
 
       function check(err) {
-        if (0 === err.message.indexOf("unsupported algorithm:") || err.message.contains("Failed to create key using named curve")) {
+        if (0 === err.message.indexOf("unsupported algorithm:") || err.message.includes("Failed to create key using named curve")) {
           impl = fallback;
           return impl.apply(null, args);
         }
@@ -108,6 +108,7 @@ exports.setupFallback = function(nodejs, webcrypto, fallback) {
 
       try {
         promise = Promise.resolve(nodejs.apply(null, args));
+        promise = promise.catch(check);
       } catch(err) {
         promise = check(err);
       }

--- a/lib/algorithms/helpers.js
+++ b/lib/algorithms/helpers.js
@@ -98,7 +98,7 @@ exports.setupFallback = function(nodejs, webcrypto, fallback) {
           promise;
 
       function check(err) {
-        if (0 === err.message.indexOf("unsupported algorithm:")) {
+        if (0 === err.message.indexOf("unsupported algorithm:") || err.message.contains("Failed to create key using named curve")) {
           impl = fallback;
           return impl.apply(null, args);
         }

--- a/lib/deps/ecc/curves.js
+++ b/lib/deps/ecc/curves.js
@@ -94,16 +94,31 @@ function secp521r1() {
   return new X9ECParameters(curve, G, n, h);
 }
 
+function bp256() {
+  var p = new BigInteger("76884956397045344220809746629001649093037950200943055203735601445031516197751");
+  var a = new BigInteger("56698187605326110043627228396178346077120614539475214109386828188763884139993");
+  var b = new BigInteger("17577232497321838841075697789794520262950426058923084567046852300633325438902");
+  var curve = new ec.ECCurveFp(p, a, b);
+  var G = curve.decodePointHex("04"
+      + "8BD2AEB9CB7E57CB2C4B482FFC81B7AFB9DE27E1E3BD23C23A4453BD9ACE3262"
+      + "547EF835C3DAC4FD97F8461A14611DC9C27745132DED8E545C1D54C72F046997");
+  var n = new BigInteger("76884956397045344220809746629001649092737531784414529538755519063063536359079");
+  var h = BigInteger.ONE;
+  return new X9ECParameters(curve, G, n, h);
+}
+
 // ----------------
 // Public API
 
 var CURVES = module.exports = {
   "secp256r1": secp256r1(),
   "secp384r1": secp384r1(),
-  "secp521r1": secp521r1()
+  "secp521r1": secp521r1(),
+  "brainpoolP256r1": bp256()
 };
 
 // also export NIST names
 CURVES["P-256"] = CURVES.secp256r1;
 CURVES["P-384"] = CURVES.secp384r1;
 CURVES["P-521"] = CURVES.secp521r1;
+CURVES["BP-256"] = CURVES.brainpoolP256r1;

--- a/lib/jwe/defaults.js
+++ b/lib/jwe/defaults.js
@@ -31,7 +31,7 @@
 var JWEDefaults = {
   zip: false,
   format: "general",
-  contentAlg: "A128CBC-HS256", // "A256GCM"
+  contentAlg: "A128CBC-HS256",
   protect: "*"
 };
 

--- a/lib/jwe/defaults.js
+++ b/lib/jwe/defaults.js
@@ -31,7 +31,7 @@
 var JWEDefaults = {
   zip: false,
   format: "general",
-  contentAlg: "A128CBC-HS256",
+  contentAlg: "A128CBC-HS256", // "A256GCM"
   protect: "*"
 };
 

--- a/lib/jwk/eckey.js
+++ b/lib/jwk/eckey.js
@@ -17,7 +17,8 @@ var JWK = {
 var SIG_ALGS = [
   "ES256",
   "ES384",
-  "ES512"
+  "ES512",
+  "BP256R1"
 ];
 var WRAP_ALGS = [
   "ECDH-ES",
@@ -35,6 +36,8 @@ function oidToCurveName(oid) {
       return "P-384";
     case "1.3.132.0.35":
       return "P-521";
+    case "1.3.36.3.3.2.8.1.1.7":
+      return "BP-256";
     default:
       return null;
   }
@@ -107,16 +110,18 @@ var JWKEcCfg = {
         if (!keys.private) {
           return [];
         }
-        return SIG_ALGS.filter(function(a) {
-          return (a === ("ES" + len));
+        var sigAlgs = SIG_ALGS.filter(function(a) {
+          return (a === ("ES" + len) || a === ("BP" + len + "R1"));
         });
+        return sigAlgs;
       case "verify":
         if (!keys.public) {
           return [];
         }
-        return SIG_ALGS.filter(function(a) {
-          return (a === ("ES" + len));
+        var sigAlgs = SIG_ALGS.filter(function(a) {
+          return (a === ("ES" + len) || a === ("BP" + len + "R1"));
         });
+        return sigAlgs
     }
   },
 
@@ -285,7 +290,8 @@ var JWKEcFactory = {
       crv = oidToCurveName(crv);
     }
     if (!crv) {
-      return null;
+      throw new Error('Unsupported curve specified')
+      // return null;
     }
 
     if (!input.parsed) {

--- a/lib/jwk/eckey.js
+++ b/lib/jwk/eckey.js
@@ -291,7 +291,6 @@ var JWKEcFactory = {
     }
     if (!crv) {
       throw new Error('Unsupported curve specified')
-      // return null;
     }
 
     if (!input.parsed) {

--- a/lib/jws/verify.js
+++ b/lib/jws/verify.js
@@ -128,6 +128,8 @@ var JWSVerifier = function(ks, globalOpts) {
           var processSig = function() {
             var sig = sigList.shift();
             if (!sig) {
+              // TODO: Here is a bug - the promise resolves twice with sigList = []
+              // in case of Error is thrown on line 227
               reject(new Error("no key found"));
               return;
             }

--- a/test/jwk/eckey-test.js
+++ b/test/jwk/eckey-test.js
@@ -230,7 +230,7 @@ describe("jwk/EC", function() {
       assert.deepEqual(algs, []);
 
       algs = JWK.EC.config.algorithms(keys, "verify");
-      assert.deepEqual(algs, ["ES256"]);
+      assert.deepEqual(algs, ["ES256", "BP256R1"]);
     });
     it("returns suite for private key", function() {
       var keys = pick(keyPair, "private");
@@ -248,7 +248,7 @@ describe("jwk/EC", function() {
       assert.deepEqual(algs, ["ECDH-ES", "ECDH-ES+A128KW", "ECDH-ES+A192KW", "ECDH-ES+A256KW"]);
 
       algs = JWK.EC.config.algorithms(keys, "sign");
-      assert.deepEqual(algs, ["ES256"]);
+      assert.deepEqual(algs, ["ES256", "BP256R1"]);
 
       algs = JWK.EC.config.algorithms(keys, "verify");
       assert.deepEqual(algs, []);


### PR DESCRIPTION
The brainpoolP256r1 curve is defined in [RFC 5639](https://datatracker.ietf.org/doc/html/rfc5639), and is a [recommended standard (PDF)](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03111/BSI-TR-03111_V-2-1_pdf.pdf?__blob=publicationFile&v=1) by the German Ministry for Information Security. This curve is used in several of the German healthcare system's digitization [standards (PDF; and also in German, sorry)](https://fachportal.gematik.de/fachportal-import/files/gemSpec_Krypt_V2.16.2.pdf) for authenticating with various specialist services.