### PR TITLE
Implement selective imports for Base64URL and UTF-8 utilities

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,8 @@ module.exports = {
   JWK: require("./jwk"),
   JWS: JWS,
   util: require("./util"),
+  base64url: require("./util/base64url"),
+  utf8: require("./util/utf8"),
   parse: require("./parse"),
   canYouSee: JWS.createVerify
 };


### PR DESCRIPTION
**Description:**
This Pull Request proposes an optimization in the way Node-Jose handles the export of common utilities such as Base64URL and UTF-8. Currently, importing any utility from the `util` package requires loading the entire module, unnecessarily increasing the bundle size.
 
My proposal is to allow the export of Base64URL and UTF-8 as independent modules, enabling developers to import only what they need. This will be done while maintaining the existing exports to ensure backward compatibility.
 
**Proposed Changes:**
- Separate export of Base64URL and UTF-8 in the `index.js`.
- Retention of the existing entry point for combined imports.
- Implementation of tests to ensure no backward compatibility issues are introduced.
 
**Future Considerations:**
In the long run, we could consider separating all Node-Jose utilities in this manner. This modularity would further improve performance and development efficiency. Performance is critical in today's development environment, and a more modular architecture would greatly benefit the Node-Jose community.
 
I am open to discussing these ideas and working together to implement the best solutions for the project. I appreciate any feedback you can provide and look forward to your opinions 😀