### PR TITLE
Handle JSON.parse failures in verify.js

### DIFF
--- a/lib/jws/verify.js
+++ b/lib/jws/verify.js
@@ -87,12 +87,15 @@ var JWSVerifier = function(ks, globalOpts) {
       // combine fields and decode signature per signatory
       sigList = sigList.map(function(s) {
         var header = clone(s.header || {});
-        var protect = s.protected ?
-                      JSON.parse(base64url.decode(s.protected, "utf8")) :
-                      {};
+        try {
+          var protect = s.protected ?
+                        JSON.parse(base64url.decode(s.protected, "utf8")) :
+                        {};
+        } catch (error) {
+          return Promise.reject(new Error("Parsing error: " + error));
+        }
         header = merge(header, protect);
         var signature = base64url.decode(s.signature);
-
         // process allowed algorithims
         if (!algSpec.match(header.alg)) {
           return Promise.reject(new Error("Algorithm not allowed: " + header.alg));


### PR DESCRIPTION
To reproduce the issue that I'm trying to fix, please try to verify a "bad" token like "foo-bar-baz": it will trigger an "unhandled promise rejection" that can't be captured in client code.